### PR TITLE
Mark state and region as mutually exclusive

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -57,13 +57,9 @@
 							"description": "e.g. US, AU, IN",
 							"type": "string"
 						},
-						"region": {
-							"type": "string",
-							"description": "If you specify a region, you don't need a state e.g. Brittany"
-						},
-						"state": {
-							"type": "string",
-							"description":"If you specify a state, you don't need a region e.g. Texas"
+						"territory": {
+							"type": { "enum": [ "region", "state" ] },
+							"description": "either a region (e.g. Brittany) or a state (e.g. Texas)"
 						}
 					}
 				},


### PR DESCRIPTION
Are state and region meant to be mutually exclusive?

It sounds like this because it says "if you have this don't specify that" and "if you have that don't specify this".

If they're not meant to be mutually exclusive, just reject and close this.
