### PR TITLE
Wrong usage of schema for array in "highlights"

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -126,8 +126,13 @@
 			  		"type": "array",
 			  		"description": "Specify multiple accomplishments",
 			  		"items": {
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising",
-			  			"type": "string"
+			  			"type": "object",
+			  			"properties": {
+			  				"accomplishment": {
+			  					"type": "string",
+			  					"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+			  				}
+			  			}
 			  		}
 			  	}
 			  }


### PR DESCRIPTION
The `items` property itself is not a string, but the current specification claims that it is. Actually, it is an `object` with `properties`.

You can see that this must be changed just one level above. In the `work` array, it has been done correctly.

I think this is nothing to discuss. Just wrong semantics.
