### PR TITLE
Optional document URL for references

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -278,6 +278,10 @@
 			  	"reference": {
 			  		"type": "string",
 			  		"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+			  	},
+			  	"document": {
+			  		"type": "string",
+			  		"description": "URL (as per RFC 3986) to a document representing this reference, e.g. PDF or scanned sheets"
 			  	}
 			  }
 				


### PR DESCRIPTION
At least in Germany, it's usual to provide copies of your references when you add them to your CV.
