### PR TITLE
Fixed issues with schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,262 +1,289 @@
 {
-	"title": "Resume Schema",
-	"type": "object",
-	"properties": {
-		"bio": {
-			"type": "object",
-			"properties": {
-				"name": {
-					"type": "string"
-				},
-				"picture": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to a picture in JPEG or PNG format"
-				},
-				"email": {
-					"type": "string",
-					"description": "e.g. thomas@gmail.com"
-				},
-				"phone": {
-					"type": "string",
-					"description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
-				},
-				"label": {
-					"type": "string",
-					"description": "e.g. Web Developer"
-				},
-				"summary": {
-					"type": "string",
-					"description": "Write a short 2-3 sentence biography about yourself"
-				},
-				"location": {
-					"type": "object",
-					"properties": {
-						"city": {
-							"type": "string"
-						},
-						"countryCode": {
-							"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN",
-							"type": "string"
-						},
-						"region": {
-							"type": "string",
-							"description": "The general region where you live. Can be a US state, or a province, for instance."
-						}
-					}
-				},
-				"website": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to your website, e.g. personal homepage"
-				},
-				"profiles": {
-					"type": "object",
-					"description": "Specify any number of social networks that you participate in",
-					"properties": {
-						"twitter": {
-							"type": "string",
-							"description": "e.g. neutralthoughts"
-						},
-						"github": {
-							"type": "string",
-							"description": "e.g. thomasdavis"
-						}
-					}
-				}
-			}
-		},
-		"work": {
-			"type": "array",
-			"items": {
-		  	"type": "object",
-				 "properties": {
-			  	"company": {
-			  		"type": "string",
-			  		"description": "e.g. Facebook"
-			  	},
-			  	"position": {
-			  		"type": "string",
-			  		"description": "e.g. Software Engineer"
-			  	},
-			  	"website": {
-			  		"type": "string",
-			  		"description": "e.g. http://facebook.com"
-			  	},
-			  	"startDate": {
-			  		"type": "string",
-			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29"
-			  	},
-			  	"endDate": {
-			  		"type": "string",
-			  		"description": "e.g. 2012-06-29"
-			  	},
-			  	"summary": {
-			  		"type": "string",
-			  		"description": "Give an overview of your responsibilities at the company"
-			  	},
-			  	"highlights": {
-			  		"type": "array",
-			  		"description": "Specify multiple accomplishments",
-			  		"items": {
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising",
-			  			"type": "string"
-			  		}
-			  	}
-			  }
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Resume Schema",
+    "type": "object",
+    "additionalProperties": false,
 
-			}
-		},
-		"education": {
-			"type": "array",
-			"items": {
-		  	"type": "object",
-				"properties": {
-				  	"institution": {
-				  		"type": "string",
-				  		"description": "e.g. Massachusetts Institute of Technology"
-				  	},
-				  	"area": {
-				  		"type": "string",
-				  		"description": "e.g. Arts"
-				  	},
-				  	"studyType": {
-				  		"type": "string",
-				  		"description": "e.g. Bachelor"
-				  	},
-				  	"startDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2014-06-29"
+    "properties": {
+        "bio": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "picture": {
+                    "type": "string",
+                    "description": "URL (as per RFC 3986) to a picture in JPEG or PNG format"
+                },
+                "email": {
+                    "type": [ "string", "object" ],
+                    "description": "e.g. thomas@gmail.com",
+                    "format": "email",
+                    "additionalProperties": {
+                        "type": "string",
+                        "format": "email"
+                    }
+                },
+                "phone": {
+                    "type": "string",
+                    "description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+                },
+                "label": {
+                    "type": "string",
+                    "description": "e.g. Web Developer"
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "Write a short 2-3 sentence biography about yourself"
+                },
+                "location": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "city": {
+                            "type": "string"
+                        },
+                        "countryCode": {
+                            "type": "string",
+                            "description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+                        },
+                        "region": {
+                            "type": "string",
+                            "description": "The general region where you live. Can be a US state, or a province, for instance."
+                        }
+                    }
+                },
+                "website": {
+                    "type": "string",
+                    "description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
+                    "format": "uri"
+                },
+                "profiles": {
+                    "type": "object",
+                    "description": "Specify any number of social networks that you participate in",
+                    "additionalProperties": {
+                        "type": "string",
+                        "description": "e.g. neutralthoughts"
+                    }
+                }
+            }
+        },
+        "work": {
+            "type": "array",
+            "additionalItems": false,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "company": {
+                        "type": "string",
+                        "description": "e.g. Facebook"
+                    },
+                    "position": {
+                        "type": "string",
+                        "description": "e.g. Software Engineer"
+                    },
+                    "website": {
+                        "type": "string",
+                        "description": "e.g. http://facebook.com",
+                        "format": "uri"
+                    },
+                    "startDate": {
+                        "type": "string",
+                        "description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+                        "format": "date"
+                    },
+                    "endDate": {
+                        "type": "string",
+                        "description": "e.g. 2012-06-29",
+                        "format": "date"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "Give an overview of your responsibilities at the company"
+                    },
+                    "highlights": {
+                        "type": "array",
+                        "description": "Specify multiple accomplishments",
+                        "additionalItems": false,
+                        "items": {
+                            "type": "string",
+                            "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+                        }
+                    }
+                }
 
-				  	},
-				  	"endDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2012-06-29"
+            }
+        },
+        "education": {
+            "type": "array",
+            "additionalItems": false,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "institution": {
+                        "type": "string",
+                        "description": "e.g. Massachusetts Institute of Technology"
+                    },
+                    "area": {
+                        "type": "string",
+                        "description": "e.g. Arts"
+                    },
+                    "studyType": {
+                        "type": "string",
+                        "description": "e.g. Bachelor"
+                    },
+                    "startDate": {
+                        "type": "string",
+                        "description": "e.g. 2014-06-29",
+                        "format": "date"
 
-				  	},
-				  	"gpa": {
-				  		"type": "string",
-				  		"description": "grade point average, e.g. 3.67/4.0"
-				  	},
-				  	"courses": {
-				  		"type": "array",
-				  		"description": "List notable courses/subjects",
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. H1302 - Introduction to American history"
-				  		}
-				  	}
-			  	}
+                    },
+                    "endDate": {
+                        "type": "string",
+                        "description": "e.g. 2012-06-29",
+                        "format": "date"
+
+                    },
+                    "gpa": {
+                        "type": "string",
+                        "description": "grade point average, e.g. 3.67/4.0"
+                    },
+                    "courses": {
+                        "type": "array",
+                        "description": "List notable courses/subjects",
+                        "items": {
+                            "type": "string",
+                            "description": "e.g. H1302 - Introduction to American history"
+                        }
+                    }
+                }
 
 
-			}
-		},
-		"awards": {
-			"type": "array",
-			"description": "Specify any awards you have received throughout your professional career",
-			"items": {
-			  	"type": "object",
-				"properties": {
-				  	"title": {
-				  		"type": "string",
-				  		"description": "e.g. One of the 100 greatest minds of the century"
-				  	},
-				  	"awardDate": {
-				  		"type": "string",
-				  		"description": "e.g. 1989-06-12"
-				  	},
-				  	"awarder": {
-				  		"type": "string",
-				  		"description": "e.g. Time Magazine"
-				  	}
-				}
-			}
-		},
-		"publications": {
-			"type": "array",
-			"description": "Specify your publications through your career",
-			"items": {
-		  	"type": "object",
-				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. The World Wide Web"
-				  	},
-				  	"publisher": {
-				  		"type": "string",
-				  		"description": "e.g. IEEE, Computer Magazine"
-				  	},
-				  	"releaseDate": {
-				  		"type": "string",
-				  		"description": "e.g. 1990-08-01"
-				  	},
-				  	"website": {
-				  		"type": "string",
-				  		"description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
-				  	}
-			  	}
-			}
-		},
-		"skills": {
-			"type": "array",
-			"description": "List out your professional skill-set",
-			"items": {
-			  	"type": "object",
-				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. Web Development"
-				  	},
-				  	"level": {
-				  		"type": "string",
-				  		"description": "e.g. Master"
-				  	},
-				  	"keywords": {
-				  		"type": "array",
-				  		"description": "List some keywords pertaining to this skill",
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. HTML"
-				  		}
-				  	}
-				}
-			}
-		},
-		"hobbies": {
-			"type": "array",
-			"items": {
-		  	"type": "object",
-				 "properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Philosophy"
-			  	},
-			  	"keywords": {
-			  		"type": "array",
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Friedrich Nietzsche"
-			  		}
-			  	}
-			  }
+            }
+        },
+        "awards": {
+            "type": "array",
+            "description": "Specify any awards you have received throughout your professional career",
+            "additionalItems": false,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "e.g. One of the 100 greatest minds of the century"
+                    },
+                    "date": {
+                        "type": "string",
+                        "description": "e.g. 1989-06-12",
+                        "format": "date"
+                    },
+                    "awarder": {
+                        "type": "string",
+                        "description": "e.g. Time Magazine"
+                    }
+                }
+            }
+        },
+        "publications": {
+            "type": "array",
+            "description": "Specify your publications through your career",
+            "additionalItems": false,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "e.g. The World Wide Web"
+                    },
+                    "publisher": {
+                        "type": "string",
+                        "description": "e.g. IEEE, Computer Magazine"
+                    },
+                    "releaseDate": {
+                        "type": "string",
+                        "description": "e.g. 1990-08-01"
+                    },
+                    "website": {
+                        "type": "string",
+                        "description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+                    }
+                }
+            }
+        },
+        "skills": {
+            "type": "array",
+            "description": "List out your professional skill-set",
+            "additionalItems": false,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "e.g. Web Development"
+                    },
+                    "level": {
+                        "type": "string",
+                        "description": "e.g. Master"
+                    },
+                    "keywords": {
+                        "type": "array",
+                        "description": "List some keywords pertaining to this skill",
+                        "items": {
+                            "type": "string",
+                            "description": "e.g. HTML"
+                        }
+                    }
+                }
+            }
+        },
+        "hobbies": {
+            "type": "array",
+            "additionalItems": false,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "e.g. Philosophy"
+                    },
+                    "keywords": {
+                        "type": "array",
+                        "additionalItems": false,
+                        "items": {
+                            "type": "string",
+                            "description": "e.g. Friedrich Nietzsche"
+                        }
+                    }
+                }
 
-			}
-		},
-		"references": {
-			"type": "array",
-			"description": "List references you have received",
-			"items": {
-		  	"type": "object",
-				 "properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Timothy Cook"
-			  	},
-			  	"reference": {
-			  		"type": "string",
-			  		"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
-			  	}
-			  }
+            }
+        },
+        "references": {
+            "type": "array",
+            "description": "List references you have received",
+            "additionalItems": false,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "e.g. Timothy Cook"
+                    },
+                    "reference": {
+                        "type": "string",
+                        "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+                    }
+                }
 
-			}
-		}
-	}
+            }
+        }
+    }
 }


### PR DESCRIPTION
The schema looks really good, but there are a few issues. 
1. `#/bio/profiles` was limited to `twitter` and `github`
2. There were not enough restriction on the format, so any JSON file would validate against this schema.

I've added tests for this schema here http://schemastore.org/test/ against two JSON resume files. The official resume file from this repo and the example from your website (thomasdavis.json). Notice that the thomasdavis.json is slightly modified. It didn't actually validate against the schema before or after I made this modification.
