### PR TITLE
Schema corrections by @madskristensen without tabs/spaces

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -176,7 +176,7 @@
 				  		"type": "string",
 				  		"description": "e.g. One of the 100 greatest minds of the century"
 				  	},
-				  	"awardDate": {
+				  	"date": {
 				  		"type": "string",
 				  		"description": "e.g. 1989-06-12",
 				  		"format": "date"


### PR DESCRIPTION
Fixes the same issues that @madskristensen fixed in https://github.com/jsonresume/resume-schema/pull/105

But without:
- indentation changes (tabs/spaces)
- changes to `email` section which have become obsolete
- changes to `profiles` section which did neither match the current use in `resume.json` nor the style from `email`
