### PR TITLE
Added address and postalCode, fixes #76

### DIFF
--- a/resume.json
+++ b/resume.json
@@ -5,6 +5,8 @@
     "phone": "(912) 555-4321",
     "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinals!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
     "location": {
+      "address": "2712 Broadway St",
+      "postalCode": "CA 94115",
       "city": "San Francisco",
       "countryCode": "US",
       "region": "California"

--- a/schema.json
+++ b/schema.json
@@ -36,6 +36,12 @@
 					"type": "object",
 					"additionalProperties": false,
 					"properties": {
+						"address": {
+							"type": "string"
+						},
+						"postalCode": {
+							"type": "string"
+						},
 						"city": {
 							"type": "string"
 						},
@@ -74,45 +80,45 @@
 			"type": "array",
 			"additionalItems": false,
 			"items": {
-		  	"type": "object",
-		  	"additionalProperties": false,
+			"type": "object",
+			"additionalProperties": false,
 			"properties": {
-			  	"company": {
-			  		"type": "string",
-			  		"description": "e.g. Facebook"
-			  	},
-			  	"position": {
-			  		"type": "string",
-			  		"description": "e.g. Software Engineer"
-			  	},
-			  	"website": {
-			  		"type": "string",
-			  		"description": "e.g. http://facebook.com",
-			  		"format": "uri"
-			  	},
-			  	"startDate": {
-			  		"type": "string",
-			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
-			  	},
-			  	"endDate": {
-			  		"type": "string",
-			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
-			  	},
-			  	"summary": {
-			  		"type": "string",
-			  		"description": "Give an overview of your responsibilities at the company"
-			  	},
-			  	"highlights": {
-			  		"type": "array",
-			  		"description": "Specify multiple accomplishments",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-			  		}
-			  	}
+				"company": {
+					"type": "string",
+					"description": "e.g. Facebook"
+				},
+				"position": {
+					"type": "string",
+					"description": "e.g. Software Engineer"
+				},
+				"website": {
+					"type": "string",
+					"description": "e.g. http://facebook.com",
+					"format": "uri"
+				},
+				"startDate": {
+					"type": "string",
+					"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+					"format": "date"
+				},
+				"endDate": {
+					"type": "string",
+					"description": "e.g. 2012-06-29",
+					"format": "date"
+				},
+				"summary": {
+					"type": "string",
+					"description": "Give an overview of your responsibilities at the company"
+				},
+				"highlights": {
+					"type": "array",
+					"description": "Specify multiple accomplishments",
+					"additionalItems": false,
+					"items": {
+						"type": "string",
+						"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+					}
+				}
 			  }
 
 			}
@@ -121,45 +127,45 @@
 			"type": "array",
 			"additionalItems": false,
 			"items": {
-		  	"type": "object",
-		  	"additionalProperties": false,
+			"type": "object",
+			"additionalProperties": false,
 			"properties": {
-				  	"institution": {
-				  		"type": "string",
-				  		"description": "e.g. Massachusetts Institute of Technology"
-				  	},
-				  	"area": {
-				  		"type": "string",
-				  		"description": "e.g. Arts"
-				  	},
-				  	"studyType": {
-				  		"type": "string",
-				  		"description": "e.g. Bachelor"
-				  	},
-				  	"startDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2014-06-29",
-			  			"format": "date"
-				  	},
-				  	"endDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2012-06-29",
-			  			"format": "date"
-				  	},
-				  	"gpa": {
-				  		"type": "string",
-				  		"description": "grade point average, e.g. 3.67/4.0"
-				  	},
-				  	"courses": {
-				  		"type": "array",
-				  		"description": "List notable courses/subjects",
-				  		"additionalItems": false,
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. H1302 - Introduction to American history"
-				  		}
-				  	}
-			  	}
+					"institution": {
+						"type": "string",
+						"description": "e.g. Massachusetts Institute of Technology"
+					},
+					"area": {
+						"type": "string",
+						"description": "e.g. Arts"
+					},
+					"studyType": {
+						"type": "string",
+						"description": "e.g. Bachelor"
+					},
+					"startDate": {
+						"type": "string",
+						"description": "e.g. 2014-06-29",
+						"format": "date"
+					},
+					"endDate": {
+						"type": "string",
+						"description": "e.g. 2012-06-29",
+						"format": "date"
+					},
+					"gpa": {
+						"type": "string",
+						"description": "grade point average, e.g. 3.67/4.0"
+					},
+					"courses": {
+						"type": "array",
+						"description": "List notable courses/subjects",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. H1302 - Introduction to American history"
+						}
+					}
+				}
 
 
 			}
@@ -169,22 +175,22 @@
 			"description": "Specify any awards you have received throughout your professional career",
 			"additionalItems": false,
 			"items": {
-			  	"type": "object",
-			  	"additionalProperties": false,
+				"type": "object",
+				"additionalProperties": false,
 				"properties": {
-				  	"title": {
-				  		"type": "string",
-				  		"description": "e.g. One of the 100 greatest minds of the century"
-				  	},
-				  	"date": {
-				  		"type": "string",
-				  		"description": "e.g. 1989-06-12",
-				  		"format": "date"
-				  	},
-				  	"awarder": {
-				  		"type": "string",
-				  		"description": "e.g. Time Magazine"
-				  	}
+					"title": {
+						"type": "string",
+						"description": "e.g. One of the 100 greatest minds of the century"
+					},
+					"date": {
+						"type": "string",
+						"description": "e.g. 1989-06-12",
+						"format": "date"
+					},
+					"awarder": {
+						"type": "string",
+						"description": "e.g. Time Magazine"
+					}
 				}
 			}
 		},
@@ -193,26 +199,26 @@
 			"description": "Specify your publications through your career",
 			"additionalItems": false,
 			"items": {
-		  		"type": "object",
-		  		"additionalProperties": false,
+				"type": "object",
+				"additionalProperties": false,
 				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. The World Wide Web"
-				  	},
-				  	"publisher": {
-				  		"type": "string",
-				  		"description": "e.g. IEEE, Computer Magazine"
-				  	},
-				  	"releaseDate": {
-				  		"type": "string",
-				  		"description": "e.g. 1990-08-01"
-				  	},
-				  	"website": {
-				  		"type": "string",
-				  		"description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
-				  	}
-			  	}
+					"name": {
+						"type": "string",
+						"description": "e.g. The World Wide Web"
+					},
+					"publisher": {
+						"type": "string",
+						"description": "e.g. IEEE, Computer Magazine"
+					},
+					"releaseDate": {
+						"type": "string",
+						"description": "e.g. 1990-08-01"
+					},
+					"website": {
+						"type": "string",
+						"description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+					}
+				}
 			}
 		},
 		"skills": {
@@ -220,26 +226,26 @@
 			"description": "List out your professional skill-set",
 			"additionalItems": false,
 			"items": {
-			  	"type": "object",
-			  	"additionalProperties": false,
+				"type": "object",
+				"additionalProperties": false,
 				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. Web Development"
-				  	},
-				  	"level": {
-				  		"type": "string",
-				  		"description": "e.g. Master"
-				  	},
-				  	"keywords": {
-				  		"type": "array",
-				  		"description": "List some keywords pertaining to this skill",
-				  		"additionalItems": false,
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. HTML"
-				  		}
-				  	}
+					"name": {
+						"type": "string",
+						"description": "e.g. Web Development"
+					},
+					"level": {
+						"type": "string",
+						"description": "e.g. Master"
+					},
+					"keywords": {
+						"type": "array",
+						"description": "List some keywords pertaining to this skill",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. HTML"
+						}
+					}
 				}
 			}
 		},
@@ -247,21 +253,21 @@
 			"type": "array",
 			"additionalItems": false,
 			"items": {
-		  	"type": "object",
-		  	"additionalProperties": false,
+			"type": "object",
+			"additionalProperties": false,
 			"properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Philosophy"
-			  	},
-			  	"keywords": {
-			  		"type": "array",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Friedrich Nietzsche"
-			  		}
-			  	}
+				"name": {
+					"type": "string",
+					"description": "e.g. Philosophy"
+				},
+				"keywords": {
+					"type": "array",
+					"additionalItems": false,
+					"items": {
+						"type": "string",
+						"description": "e.g. Friedrich Nietzsche"
+					}
+				}
 			  }
 
 			}
@@ -271,17 +277,17 @@
 			"description": "List references you have received",
 			"additionalItems": false,
 			"items": {
-		  	"type": "object",
-		  	"additionalProperties": false,
+			"type": "object",
+			"additionalProperties": false,
 			"properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Timothy Cook"
-			  	},
-			  	"reference": {
-			  		"type": "string",
-			  		"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
-			  	}
+				"name": {
+					"type": "string",
+					"description": "e.g. Timothy Cook"
+				},
+				"reference": {
+					"type": "string",
+					"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+				}
 			  }
 
 			}


### PR DESCRIPTION
New PR for adding address and postalCode, without fixing tabs. 

We should really fix that soon though, because we've chosen a convention and then we should stick to it. Currently resume.json uses spaces, while schema.json uses tabs.
