### PR TITLE
Use json-schema.org/address# for `location`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -33,27 +33,7 @@
 					"description": "Write a short 2-3 sentence biography about yourself"
 				},
 				"location": {
-					"type": "object",
-					"additionalProperties": false,
-					"properties": {
-						"address": {
-							"type": "string"
-						},
-						"postalCode": {
-							"type": "string"
-						},
-						"city": {
-							"type": "string"
-						},
-						"countryCode": {
-							"type": "string",
-							"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
-						},
-						"region": {
-							"type": "string",
-							"description": "The general region where you live. Can be a US state, or a province, for instance."
-						}
-					}
+					"$ref": "http://json-schema.org/address#"
 				},
 				"website": {
 					"type": "string",


### PR DESCRIPTION
Instead of defining your own `location` type, why not use the one already specified on the official JSON Schema website?