### PR TITLE
certificates section added

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -171,6 +171,34 @@
 
 			}
 		},
+		"certificates": {
+			"type": "array",
+			"description": "Specify any certificates you have been awarded",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. M101P: MongoDB for Developers"
+					},
+					"institution": {
+						"type": "string",
+						"description": "e.g. MongoDB University"
+					},
+					"receiveDate": {
+						"type": "string",
+						"description": "e.g. 2014-03-25",
+						"format": "date"
+					},
+					"website": {
+						"type": "string",
+						"description": "e.g. https://s3.amazonaws.com/edu-cert.10gen.com/downloads/b5f42dc3aa1d4add9f1dc6ed290f1c81/Certificate.pdf"
+					}
+				}
+			}
+		},
 		"awards": {
 			"type": "array",
 			"description": "Specify any awards you have received throughout your professional career",


### PR DESCRIPTION
There is no section that I could write my certificates into. There is an "education" section, however, it refers to the courses I have taken during my college/uni studies. And where shall I put a foreign language certificate? Or a Microsoft .Net Developer certificate? Below is my suggestion for adding `certificate` section.

I can see there is schema.json.html file that is generated, basing on schema.json file. Unfortunately, I don't know the tool that has been used to generate the .html file. Please provide information, so that I can do it (besides: how about adding it to README?)