### PR TITLE
Updated website, awards, and skills sections

### DIFF
--- a/resume.json
+++ b/resume.json
@@ -58,11 +58,11 @@
   }],
   "skills": [{
     "name": "Web Development",
-    "level": "Master",
+    "experience": "10+ years",
     "keywords": ["HTML", "CSS", "Javascript"]
   },{
     "name": "Compression",
-    "level": "Master",
+    "experience": "10+ years",
     "keywords": ["Mpeg", "MP4", "GIF"]
   }],
   "references": [{

--- a/schema.json
+++ b/schema.json
@@ -253,9 +253,9 @@
 				  		"type": "string",
 				  		"description": "e.g. Web Development"
 				  	},
-				  	"level": {
+				  	"experience": {
 				  		"type": "string",
-				  		"description": "e.g. Master"
+				  		"description": "e.g. 10+ years"
 				  	},
 				  	"keywords": {
 				  		"type": "array",


### PR DESCRIPTION
I expanded the "website" section into "websites" to allow multiple non-social network websites to be included.  I also added a "description" field to awards to help provide more context (especially useful for internal awards).  Finally I renamed "level" to "experience" within skills.  Without any structure to this field, people could still put in "Master", but years of experience seemed less subjective.
