### PR TITLE
Change validate callback to follow node convention

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var validator = require('../validator');
 
 test('Test validator on resume.json.', function(t) {
-    validator.validate(validator.resumeJson, function(report, err) {
+    validator.validate(validator.resumeJson, function(err, report) {
         t.equal(err, null, 'No formatting errors');
         t.equal(report && report.valid, true, 'Passes JsonResume v1.0.0 specification - DRAFT.');
         t.end();

--- a/validator.js
+++ b/validator.js
@@ -12,14 +12,14 @@ var schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'schema.json'), 
 function validate(resumeJson, callback) {
     ZSchema.validate(resumeJson, schema)
         .then(function(report) {
-            callback(report, null);
+            callback(null, report);
         })
         .
     catch (function(err) {
-        callback(null, err);
-    })
+        callback(err, null);
+    });
 }
 module.exports = {
     validate: validate,
     resumeJson: resumeJson
-}
+};


### PR DESCRIPTION
Small change to switch params for the validate callback to follow node callback convention `(err, result)`
