### PR TITLE
Add 'certifications' property

### DIFF
--- a/resume.json
+++ b/resume.json
@@ -77,6 +77,14 @@
       "summary": "There is no spoon."
     }
   ],
+  "certifications":[
+  	{
+	  "name": "Oracle Certified Associate",
+	  "date": "1992-04-01",
+	  "governingBody": "Oracle Inc.",
+	  "id": "5556" 
+	}
+  ]
   "publications": [
     {
       "name": "Video compression for 3d media",

--- a/resume.json
+++ b/resume.json
@@ -77,12 +77,18 @@
       "summary": "There is no spoon."
     }
   ],
-  "certifications":[
+  "qualifications":[
   	{
 	  "name": "Oracle Certified Associate",
 	  "date": "1992-04-01",
 	  "governingBody": "Oracle Inc.",
 	  "id": "5556" 
+	},
+	{
+	  "name": "New York Licenced Teacher",
+	  "date": "1989-06-21",
+	  "governingBody": "New York State Education Dept.",
+	  "id": "LD34569" 
 	}
   ]
   "publications": [

--- a/schema.json
+++ b/schema.json
@@ -90,47 +90,46 @@
 			"type": "array",
 			"additionalItems": false,
 			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"company": {
-			  		"type": "string",
-			  		"description": "e.g. Facebook"
-			  	},
-			  	"position": {
-			  		"type": "string",
-			  		"description": "e.g. Software Engineer"
-			  	},
-			  	"website": {
-			  		"type": "string",
-			  		"description": "e.g. http://facebook.com",
-			  		"format": "uri"
-			  	},
-			  	"startDate": {
-			  		"type": "string",
-			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
-			  	},
-			  	"endDate": {
-			  		"type": "string",
-			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
-			  	},
-			  	"summary": {
-			  		"type": "string",
-			  		"description": "Give an overview of your responsibilities at the company"
-			  	},
-			  	"highlights": {
-			  		"type": "array",
-			  		"description": "Specify multiple accomplishments",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-			  		}
-			  	}
-			  }
-
+			  	"type": "object",
+			  	"additionalProperties": true,
+				"properties": {
+				  	"company": {
+				  		"type": "string",
+				  		"description": "e.g. Facebook"
+				  	},
+				  	"position": {
+				  		"type": "string",
+				  		"description": "e.g. Software Engineer"
+				  	},
+				  	"website": {
+				  		"type": "string",
+				  		"description": "e.g. http://facebook.com",
+				  		"format": "uri"
+				  	},
+				  	"startDate": {
+				  		"type": "string",
+				  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+				  		"format": "date"
+				  	},
+				  	"endDate": {
+				  		"type": "string",
+				  		"description": "e.g. 2012-06-29",
+				  		"format": "date"
+				  	},
+				  	"summary": {
+				  		"type": "string",
+				  		"description": "Give an overview of your responsibilities at the company"
+				  	},
+				  	"highlights": {
+				  		"type": "array",
+				  		"description": "Specify multiple accomplishments",
+				  		"additionalItems": false,
+				  		"items": {
+				  			"type": "string",
+				  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+				  		}
+				  	}
+				  }
 			}
 		},
 		"volunteer": {
@@ -253,6 +252,33 @@
 				  		"description": "e.g. Received for my work with Quantum Physics"
 				  	}
 				}
+			}
+		},
+		"certifications":{
+			"type": "array",
+			"description": "List your valid and current certifications, licences, and accreditations",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+			  	"additionalProperties": true,
+				"properties": {
+				  	"name": {
+				  		"type": "string",
+				  		"description": "e.g. Certified Public Accountant, New York Certified Teacher"
+				  	},
+				  	"date": {
+				  		"type": "string",
+				  		"description": "e.g. 1989-06-12",
+				  		"format": "date"
+				  	},
+				  	"governingBody": {
+				  		"type": "string",
+				  		"description": "e.g. American Institute of Certified Public Accountants, NY State Education Department"
+				  	},
+				  	"id": {
+				  		"type": "string",
+				  		"description": "Individual license or certificate number"
+				  	}
 			}
 		},
 		"publications": {

--- a/schema.json
+++ b/schema.json
@@ -254,7 +254,7 @@
 				}
 			}
 		},
-		"certifications":{
+		"qualifications":{
 			"type": "array",
 			"description": "List your valid and current certifications, licences, and accreditations",
 			"additionalItems": false,


### PR DESCRIPTION
Suggesting a new top-level property for professional certifications. 

The accounting, legal, teaching, and even transportation and communication industries, for example, all have significant accreditation requirements; a place for which is totally lacking from the current spec.

Thoughts?