### PR TITLE
Add custom date validator

### DIFF
--- a/resume.json
+++ b/resume.json
@@ -47,8 +47,8 @@
       "organization": "CoderDojo",
       "position": "Teacher",
       "website": "http://coderdojo.com/",
-      "startDate": "2012-01-01",
-      "endDate": "2013-01-01",
+      "startDate": "2012-01",
+      "endDate": "2013-01",
       "summary": "Global movement of free coding clubs for young people.",
       "highlights": [
         "Awarded 'Teacher of the Month'"
@@ -60,8 +60,8 @@
       "institution": "University of Oklahoma",
       "area": "Information Technology",
       "studyType": "Bachelor",
-      "startDate": "2011-06-01",
-      "endDate": "2014-01-01",
+      "startDate": "2011-06",
+      "endDate": "2014",
       "gpa": "4.0",
       "courses": [
         "DB1101 - Basic SQL",

--- a/schema.json
+++ b/schema.json
@@ -109,12 +109,12 @@
 			  	"startDate": {
 			  		"type": "string",
 			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
+			  		"format": "resume-date"
 			  	},
 			  	"endDate": {
 			  		"type": "string",
 			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
+			  		"format": "resume-date"
 			  	},
 			  	"summary": {
 			  		"type": "string",
@@ -156,12 +156,12 @@
 			  	"startDate": {
 			  		"type": "string",
 			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
+			  		"format": "resume-date"
 			  	},
 			  	"endDate": {
 			  		"type": "string",
 			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
+			  		"format": "resume-date"
 			  	},
 			  	"summary": {
 			  		"type": "string",
@@ -202,12 +202,12 @@
 				  	"startDate": {
 				  		"type": "string",
 			  			"description": "e.g. 2014-06-29",
-			  			"format": "date"
+			  			"format": "resume-date"
 				  	},
 				  	"endDate": {
 				  		"type": "string",
 			  			"description": "e.g. 2012-06-29",
-			  			"format": "date"
+			  			"format": "resume-date"
 				  	},
 				  	"gpa": {
 				  		"type": "string",
@@ -242,7 +242,7 @@
 				  	"date": {
 				  		"type": "string",
 				  		"description": "e.g. 1989-06-12",
-				  		"format": "date"
+				  		"format": "resume-date"
 				  	},
 				  	"awarder": {
 				  		"type": "string",

--- a/validator.js
+++ b/validator.js
@@ -5,16 +5,25 @@ var resumeJson = require('./resume');
 
 
 /* Register custom validators */
+
+/**
+ * Register a custom date validator "resume-date" that allows:
+ *
+ * - "YYYY-MM-DD" : year, month, and day
+ * - "YYYY-MM"    : year and month
+ * - "YYYY"       : year
+ * - ""           : empty string represents the present
+ */
 ZSchema.registerFormat('resume-date', function (date) {
   if (typeof date !== 'string') {
     return true;
   }
-  var matches = /^[0-9]{4}(-([0-9]{2})(-([0-9]{2}))?)?$/.exec(date);
+  var matches = /^([0-9]{4}(-([0-9]{2})(-([0-9]{2}))?)?)?$/.exec(date);
   if (matches === null) {
     return false
   }
-  var month = matches[2];
-  var day = matches[4];
+  var month = matches[3];
+  var day = matches[5];
   return !(month < '01' || month > '12' || day < '01' || day > '31');
 });
 

--- a/validator.js
+++ b/validator.js
@@ -3,6 +3,22 @@ var fs = require('fs');
 var path = require('path');
 var resumeJson = require('./resume');
 
+
+/* Register custom validators */
+ZSchema.registerFormat('resume-date', function (date) {
+  if (typeof date !== 'string') {
+    return true;
+  }
+  var matches = /^[0-9]{4}(-([0-9]{2})(-([0-9]{2}))?)?$/.exec(date);
+  if (matches === null) {
+    return false
+  }
+  var month = matches[2];
+  var day = matches[4];
+  return !(month < '01' || month > '12' || day < '01' || day > '31');
+});
+
+
 // TODO - Remove this sync call
 var schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'schema.json'), 'utf8'));
 
@@ -19,4 +35,4 @@ function validate(resumeJson, callback) {
 module.exports = {
     validate: validate,
     resumeJson: resumeJson
-}
+};


### PR DESCRIPTION
Allows matching dates formatted as YYYY-MM-DD, YYYY-MM, or just YYYY, as per https://github.com/jsonresume/resume-schema/issues/142.

Also allows the empty string, to represent the present.

Is this the right approach? Perhaps custom validators should be extracted into a separate module and unit-tested?