### PR TITLE
Export the schema from the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ var resumeObject = JSON.parse(fs.readFileSync('resume.json', 'utf8'));
 resumeSchema.validate(resumeObject);
 ```
 
+The JSON Resume schema is available from:
+
+```js
+require('resume-schema').schema;
+```
+
 ### People
 
 * Julian Shapiro for early prototype revisions

--- a/test/index.js
+++ b/test/index.js
@@ -18,3 +18,8 @@ test('Validates an invalid resume', function(t) {
     t.end();
   });
 });
+
+test('Exports the JSON schema', function(t) {
+  t.ok(validator.schema, 'JSON Schema is being exported');
+  t.end();
+});

--- a/validator.js
+++ b/validator.js
@@ -4,9 +4,7 @@ var ZSchema = require('z-schema');
 var fs = require('fs');
 var path = require('path');
 var resumeJson = require('./resume');
-
-// TODO - Remove this sync call
-var schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'schema.json'), 'utf8'));
+var schema = require('./schema');
 
 function validate(resumeJson, callback) {
   ZSchema.validate(resumeJson, schema)
@@ -18,5 +16,6 @@ function validate(resumeJson, callback) {
 
 module.exports = {
   validate: validate,
-  resumeJson: resumeJson
+  resumeJson: resumeJson,
+  schema: schema
 };


### PR DESCRIPTION
The resume-schema package should export the Resume JSON schema, so that it's possible to implement my own validation or to convert/display the schema in another format.
