### PR TITLE
Set files list in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "bugs": {
         "url": "https://github.com/jsonresume/resume-schema/issues"
     },
+    "files": [
+        "resume.json",
+        "schema.json",
+        "validator.js"
+    ],
     "dependencies": {
         "z-schema": "~2.4.8"
     },


### PR DESCRIPTION
Right now when someone installs resume-schema with npm, they also download the docs dir, the PDF in research dir and lots of other files than are not required to have in the package deployed at NPM. By setting the [`files`](https://docs.npmjs.com/files/package.json#files) property, we whitelist only the files that are necessary to be in the package. LICENSE.md, README.md and package.json are included by default, so they don't need to be whitelisted.