### PR TITLE
Use promises instead of callback for validate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,10 @@ To use
 
 ```
 var resumeSchema  = require('resume-schema');
-resumeSchema.validate({ name: "Thomas" }, function (err, report) {
-  if (err) {
-    console.error('The resume was invalid:', err);
-    return;
-  }
+resumeSchema.validate({ name: "Thomas" }).then(function(report) {
   console.log('Resume validated successfully:', report);
+}, function(err) {
+  console.error('The resume was invalid:', err);
 });
 ```
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
 var test = require('tape');
 var validator = require('../validator');
+var resumeJson = require('../resume.json');
 
 test('Validates a valid resume', function(t) {
-  validator.validate(validator.resumeJson, function(err, report) {
-    t.equal(err, null, 'No formatting errors');
+  validator.validate(resumeJson).then(function(report) {
     t.equal(report && report.valid, true, 'Passes JsonResume v1.0.0 specification - DRAFT.');
     t.end();
   });
@@ -13,7 +13,7 @@ test('Validates an invalid resume', function(t) {
   validator.validate({
     basics: [],
     profiles: {}
-  }, function(err) {
+  }).catch(function(err) {
     t.ok(err, 'Error is triggered by validation');
     t.end();
   });

--- a/validator.js
+++ b/validator.js
@@ -3,20 +3,12 @@
 var ZSchema = require('z-schema');
 var fs = require('fs');
 var path = require('path');
-var resumeJson = require('./resume');
-
-// TODO - Remove this sync call
-var schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'schema.json'), 'utf8'));
+var schema = require('./schema.json');
 
 function validate(resumeJson, callback) {
-  ZSchema.validate(resumeJson, schema)
-    .then(function(report) {
-      callback(null, report);
-    })
-    .catch(callback);
+  return ZSchema.validate(resumeJson, schema);
 }
 
 module.exports = {
-  validate: validate,
-  resumeJson: resumeJson
+  validate: validate
 };


### PR DESCRIPTION
Since the schema validator was already using a promise, might as well just return that instead of using callbacks which are a pain to use.  Updated test and readme to reflect the changes.  I also made the retrieval of the schema easier by simply using `require` instead of `JSON.parse(fs.readFileSync(path.resolve(`.