### PR TITLE
Add (minimal) metadata to schema #204

### DIFF
--- a/resume.json
+++ b/resume.json
@@ -127,7 +127,7 @@
       "reference": "It is my pleasure to recommend Richard, his performance working as a consultant for Main St. Company proved that he will be a valuable addition to any company."
     }
   ],
-  "metadata": {
+  "meta": {
     "url": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/resume.json",
     "dateModified": 1461755909
   }

--- a/resume.json
+++ b/resume.json
@@ -126,5 +126,9 @@
       "name": "Erlich Bachman",
       "reference": "It is my pleasure to recommend Richard, his performance working as a consultant for Main St. Company proved that he will be a valuable addition to any company."
     }
-  ]
+  ],
+  "metadata": {
+    "url": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/resume.json",
+    "dateModified": 1461755909
+  }
 }

--- a/schema.json
+++ b/schema.json
@@ -386,7 +386,7 @@
 				"description": "URL (as per RFC 3986) to latest version of this document"
 			}
 			},
-			"description": "List any key-value pairs related to this document"
+			"description": "The schema version and any other tooling configuration lives here"
 		}
 	}
 }

--- a/schema.json
+++ b/schema.json
@@ -375,7 +375,7 @@
 			  }
 			}
 		},
-		"metadata": {
+		"meta": {
 			"type": "object",
 			"additionalProperties": {
 				"type": ["string", "number"]

--- a/schema.json
+++ b/schema.json
@@ -377,9 +377,7 @@
 		},
 		"meta": {
 			"type": "object",
-			"additionalProperties": {
-				"type": ["string", "number"]
-	  		},
+			"additionalProperties": true,
 			"properties": {
 			"url": {
 				"type": "string",

--- a/schema.json
+++ b/schema.json
@@ -375,6 +375,19 @@
 			  }
 
 			}
-		}
+		},
+		"metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number"]
+          },
+          "properties": {
+          	"url": {
+              "type": "string",
+              "description": "URL (as per RFC 3986) to latest version of this document"
+            }
+          },
+          "description": "List any key-value pairs related to this document"
+        }
 	}
 }

--- a/schema.json
+++ b/schema.json
@@ -373,21 +373,20 @@
 			  		"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
 			  	}
 			  }
-
 			}
 		},
 		"metadata": {
-          "type": "object",
-          "additionalProperties": {
-            "type": ["string", "number"]
-          },
-          "properties": {
-          	"url": {
-              "type": "string",
-              "description": "URL (as per RFC 3986) to latest version of this document"
-            }
-          },
-          "description": "List any key-value pairs related to this document"
-        }
+			"type": "object",
+			"additionalProperties": {
+				"type": ["string", "number"]
+	  		},
+			"properties": {
+			"url": {
+				"type": "string",
+				"description": "URL (as per RFC 3986) to latest version of this document"
+			}
+			},
+			"description": "List any key-value pairs related to this document"
+		}
 	}
 }


### PR DESCRIPTION
There has been some discussion about adding a metadata section to the schema. So I have wrote this as a suggestion.

The desire to have a metadata section has been mentioned in different issues. What most of these have in common is that it needs to store information that is not related to the person of the resume, but to the document itself. For example a URL where the document is hosted or a version number of the document.

I thinks this type of information indeed warrants a new section, so I've added a single metadata object in the resume schema.

Since this is a section where different tools and programs might need different keys, I've allowed for additional properties. Since the issue specified a list of key/value pair, the additional properties are only allowed to be string and numbers, not arrays or objects.

Any feedback is welcome
