### PR TITLE
Change location type to address and add it to more sections

### DIFF
--- a/resume.json
+++ b/resume.json
@@ -8,10 +8,10 @@
     "website": "http://richardhendricks.com",
     "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinals!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
     "location": {
-      "address": "2712 Broadway St",
-      "postalCode": "CA 94115",
-      "city": "San Francisco",
-      "countryCode": "US",
+      "street-address": "2712 Broadway St",
+      "postal-code": "CA 94115",
+      "locality": "San Francisco",
+      "country-name": "United States of America",
       "region": "California"
     },
     "profiles": [

--- a/schema.json
+++ b/schema.json
@@ -38,28 +38,7 @@
 					"description": "Write a short 2-3 sentence biography about yourself"
 				},
 				"location": {
-					"type": "object",
-					"additionalProperties": true,
-					"properties": {
-						"address": {
-							"type": "string",
-							"description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
-						},
-						"postalCode": {
-							"type": "string"
-						},
-						"city": {
-							"type": "string"
-						},
-						"countryCode": {
-							"type": "string",
-							"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
-						},
-						"region": {
-							"type": "string",
-							"description": "The general region where you live. Can be a US state, or a province, for instance."
-						}
-					}
+					"$ref": "http://json-schema.org/address#"
 				},
 				"profiles": {
 					"type": "array",
@@ -106,6 +85,9 @@
 			  		"description": "e.g. http://facebook.com",
 			  		"format": "uri"
 			  	},
+			  	"location": {
+			  		"$ref": "http://json-schema.org/address#"
+			  	},
 			  	"startDate": {
 			  		"type": "string",
 			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
@@ -130,7 +112,6 @@
 			  		}
 			  	}
 			  }
-
 			}
 		},
 		"volunteer": {
@@ -152,6 +133,9 @@
 			  		"type": "string",
 			  		"description": "e.g. http://facebook.com",
 			  		"format": "uri"
+			  	},
+			  	"location": {
+			  		"$ref": "http://json-schema.org/address#"
 			  	},
 			  	"startDate": {
 			  		"type": "string",
@@ -190,6 +174,9 @@
 				  	"institution": {
 				  		"type": "string",
 				  		"description": "e.g. Massachusetts Institute of Technology"
+				  	},
+				  	"location": {
+				  		"$ref": "http://json-schema.org/address#"
 				  	},
 				  	"area": {
 				  		"type": "string",


### PR DESCRIPTION
Since #209 is marked as PR needed I wrote this commit.

Some things to note:
- The `address` type makes `locality`, `region` and `country-name` required. Isn't this too rigid?
- The json schema seems to use hyphenated naming, where resume schema uses camel-cased naming. Is this a problem?
  
  fixes #63
  fixes #209
