### PR TITLE
Changes tabs to spaces

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,390 +1,385 @@
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
-	"title": "Resume Schema",
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"basics": {
-			"type": "object",
-			"additionalProperties": true,
-			"properties": {
-				"name": {
-					"type": "string"
-				},
-				"label": {
-					"type": "string",
-					"description": "e.g. Web Developer"
-				},
-				"picture": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to a picture in JPEG or PNG format"
-				},
-				"email": {
-					"type": "string",
-					"description": "e.g. thomas@gmail.com",
-					"format": "email"
-				},
-				"phone": {
-					"type": "string",
-					"description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
-				},
-				"website": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
-					"format": "uri"
-				},
-				"summary": {
-					"type": "string",
-					"description": "Write a short 2-3 sentence biography about yourself"
-				},
-				"location": {
-					"type": "object",
-					"additionalProperties": true,
-					"properties": {
-						"address": {
-							"type": "string",
-							"description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
-						},
-						"postalCode": {
-							"type": "string"
-						},
-						"city": {
-							"type": "string"
-						},
-						"countryCode": {
-							"type": "string",
-							"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
-						},
-						"region": {
-							"type": "string",
-							"description": "The general region where you live. Can be a US state, or a province, for instance."
-						}
-					}
-				},
-				"profiles": {
-					"type": "array",
-					"description": "Specify any number of social networks that you participate in",
-					"additionalItems": false,
-					"items": {
-						"type": "object",
-						"additionalProperties": true,
-						"properties": {
-							"network": {
-								"type": "string",
-								"description": "e.g. Facebook or Twitter"
-							},
-							"username": {
-								"type": "string",
-								"description": "e.g. neutralthoughts"
-							},
-							"url": {
-								"type": "string",
-								"description": "e.g. http://twitter.com/neutralthoughts"
-							}
-						}
-					}
-				}
-			}
-		},
-		"work": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"company": {
-			  		"type": "string",
-			  		"description": "e.g. Facebook"
-			  	},
-			  	"position": {
-			  		"type": "string",
-			  		"description": "e.g. Software Engineer"
-			  	},
-			  	"website": {
-			  		"type": "string",
-			  		"description": "e.g. http://facebook.com",
-			  		"format": "uri"
-			  	},
-			  	"startDate": {
-			  		"type": "string",
-			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
-			  	},
-			  	"endDate": {
-			  		"type": "string",
-			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
-			  	},
-			  	"summary": {
-			  		"type": "string",
-			  		"description": "Give an overview of your responsibilities at the company"
-			  	},
-			  	"highlights": {
-			  		"type": "array",
-			  		"description": "Specify multiple accomplishments",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-			  		}
-			  	}
-			  }
-
-			}
-		},
-		"volunteer": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"organization": {
-			  		"type": "string",
-			  		"description": "e.g. Facebook"
-			  	},
-			  	"position": {
-			  		"type": "string",
-			  		"description": "e.g. Software Engineer"
-			  	},
-			  	"website": {
-			  		"type": "string",
-			  		"description": "e.g. http://facebook.com",
-			  		"format": "uri"
-			  	},
-			  	"startDate": {
-			  		"type": "string",
-			  		"description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
-			  		"format": "date"
-			  	},
-			  	"endDate": {
-			  		"type": "string",
-			  		"description": "e.g. 2012-06-29",
-			  		"format": "date"
-			  	},
-			  	"summary": {
-			  		"type": "string",
-			  		"description": "Give an overview of your responsibilities at the company"
-			  	},
-			  	"highlights": {
-			  		"type": "array",
-			  		"description": "Specify multiple accomplishments",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-			  		}
-			  	}
-			  }
-
-			}
-		},
-		"education": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-				  	"institution": {
-				  		"type": "string",
-				  		"description": "e.g. Massachusetts Institute of Technology"
-				  	},
-				  	"area": {
-				  		"type": "string",
-				  		"description": "e.g. Arts"
-				  	},
-				  	"studyType": {
-				  		"type": "string",
-				  		"description": "e.g. Bachelor"
-				  	},
-				  	"startDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2014-06-29",
-			  			"format": "date"
-				  	},
-				  	"endDate": {
-				  		"type": "string",
-			  			"description": "e.g. 2012-06-29",
-			  			"format": "date"
-				  	},
-				  	"gpa": {
-				  		"type": "string",
-				  		"description": "grade point average, e.g. 3.67/4.0"
-				  	},
-				  	"courses": {
-				  		"type": "array",
-				  		"description": "List notable courses/subjects",
-				  		"additionalItems": false,
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. H1302 - Introduction to American history"
-				  		}
-				  	}
-			  	}
-
-
-			}
-		},
-		"awards": {
-			"type": "array",
-			"description": "Specify any awards you have received throughout your professional career",
-			"additionalItems": false,
-			"items": {
-			  	"type": "object",
-			  	"additionalProperties": true,
-				"properties": {
-				  	"title": {
-				  		"type": "string",
-				  		"description": "e.g. One of the 100 greatest minds of the century"
-				  	},
-				  	"date": {
-				  		"type": "string",
-				  		"description": "e.g. 1989-06-12",
-				  		"format": "date"
-				  	},
-				  	"awarder": {
-				  		"type": "string",
-				  		"description": "e.g. Time Magazine"
-				  	},
-				  	"summary": {
-				  		"type": "string",
-				  		"description": "e.g. Received for my work with Quantum Physics"
-				  	}
-				}
-			}
-		},
-		"publications": {
-			"type": "array",
-			"description": "Specify your publications through your career",
-			"additionalItems": false,
-			"items": {
-		  		"type": "object",
-		  		"additionalProperties": true,
-				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. The World Wide Web"
-				  	},
-				  	"publisher": {
-				  		"type": "string",
-				  		"description": "e.g. IEEE, Computer Magazine"
-				  	},
-				  	"releaseDate": {
-				  		"type": "string",
-				  		"description": "e.g. 1990-08-01"
-				  	},
-				  	"website": {
-				  		"type": "string",
-				  		"description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
-				  	},
-				  	"summary": {
-				  		"type": "string",
-				  		"description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
-				  	}
-			  	}
-			}
-		},
-		"skills": {
-			"type": "array",
-			"description": "List out your professional skill-set",
-			"additionalItems": false,
-			"items": {
-			  	"type": "object",
-			  	"additionalProperties": true,
-				"properties": {
-				  	"name": {
-				  		"type": "string",
-				  		"description": "e.g. Web Development"
-				  	},
-				  	"level": {
-				  		"type": "string",
-				  		"description": "e.g. Master"
-				  	},
-				  	"keywords": {
-				  		"type": "array",
-				  		"description": "List some keywords pertaining to this skill",
-				  		"additionalItems": false,
-				  		"items": {
-				  			"type": "string",
-				  			"description": "e.g. HTML"
-				  		}
-				  	}
-				}
-			}
-		},
-		"languages": {
-			"type": "array",
-			"description": "List any other languages you speak",
-			"additionalItems": false,
-			"items": {
-				"type": "object",
-				"additionalProperties": true,
-				"properties": {
-					"language": {
-						"type": "string",
-						"description": "e.g. English, Spanish"
-					},
-					"fluency": {
-						"type": "string",
-						"description": "e.g. Fluent, Beginner"
-					}
-				}
-			}
-		},
-		"interests": {
-			"type": "array",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Philosophy"
-			  	},
-			  	"keywords": {
-			  		"type": "array",
-			  		"additionalItems": false,
-			  		"items": {
-			  			"type": "string",
-			  			"description": "e.g. Friedrich Nietzsche"
-			  		}
-			  	}
-			  }
-
-			}
-		},
-		"references": {
-			"type": "array",
-			"description": "List references you have received",
-			"additionalItems": false,
-			"items": {
-		  	"type": "object",
-		  	"additionalProperties": true,
-			"properties": {
-			  	"name": {
-			  		"type": "string",
-			  		"description": "e.g. Timothy Cook"
-			  	},
-			  	"reference": {
-			  		"type": "string",
-			  		"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
-			  	}
-			  }
-			}
-		},
-		"meta": {
-			"type": "object",
-			"additionalProperties": true,
-			"properties": {
-			"url": {
-				"type": "string",
-				"description": "URL (as per RFC 3986) to latest version of this document"
-			}
-			},
-			"description": "The schema version and any other tooling configuration lives here"
-		}
-	}
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Resume Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "basics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string",
+          "description": "e.g. Web Developer"
+        },
+        "picture": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to a picture in JPEG or PNG format"
+        },
+        "email": {
+          "type": "string",
+          "description": "e.g. thomas@gmail.com",
+          "format": "email"
+        },
+        "phone": {
+          "type": "string",
+          "description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+        },
+        "website": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
+          "format": "uri"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Write a short 2-3 sentence biography about yourself"
+        },
+        "location": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
+            },
+            "postalCode": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+            },
+            "region": {
+              "type": "string",
+              "description": "The general region where you live. Can be a US state, or a province, for instance."
+            }
+          }
+        },
+        "profiles": {
+          "type": "array",
+          "description": "Specify any number of social networks that you participate in",
+          "additionalItems": false,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "network": {
+                "type": "string",
+                "description": "e.g. Facebook or Twitter"
+              },
+              "username": {
+                "type": "string",
+                "description": "e.g. neutralthoughts"
+              },
+              "url": {
+                "type": "string",
+                "description": "e.g. http://twitter.com/neutralthoughts"
+              }
+            }
+          }
+        }
+      }
+    },
+    "work": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "company": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "website": {
+            "type": "string",
+            "description": "e.g. http://facebook.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2012-06-29",
+            "format": "date"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple accomplishments",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "volunteer": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "organization": {
+            "type": "string",
+            "description": "e.g. Facebook"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer"
+          },
+          "website": {
+            "type": "string",
+            "description": "e.g. http://facebook.com",
+            "format": "uri"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "resume.json uses the ISO 8601 date standard e.g. 2014-06-29",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2012-06-29",
+            "format": "date"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple accomplishments",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+            }
+          }
+        }
+      }
+    },
+    "education": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "institution": {
+            "type": "string",
+            "description": "e.g. Massachusetts Institute of Technology"
+          },
+          "area": {
+            "type": "string",
+            "description": "e.g. Arts"
+          },
+          "studyType": {
+            "type": "string",
+            "description": "e.g. Bachelor"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "e.g. 2014-06-29",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2012-06-29",
+            "format": "date"
+          },
+          "gpa": {
+            "type": "string",
+            "description": "grade point average, e.g. 3.67/4.0"
+          },
+          "courses": {
+            "type": "array",
+            "description": "List notable courses/subjects",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. H1302 - Introduction to American history"
+            }
+          }
+        }
+      }
+    },
+    "awards": {
+      "type": "array",
+      "description": "Specify any awards you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "e.g. One of the 100 greatest minds of the century"
+          },
+          "date": {
+            "type": "string",
+            "description": "e.g. 1989-06-12",
+            "format": "date"
+          },
+          "awarder": {
+            "type": "string",
+            "description": "e.g. Time Magazine"
+          },
+          "summary": {
+            "type": "string",
+            "description": "e.g. Received for my work with Quantum Physics"
+          }
+        }
+      }
+    },
+    "publications": {
+      "type": "array",
+      "description": "Specify your publications through your career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. The World Wide Web"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "e.g. IEEE, Computer Magazine"
+          },
+          "releaseDate": {
+            "type": "string",
+            "description": "e.g. 1990-08-01"
+          },
+          "website": {
+            "type": "string",
+            "description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+          }
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "description": "List out your professional skill-set",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Web Development"
+          },
+          "level": {
+            "type": "string",
+            "description": "e.g. Master"
+          },
+          "keywords": {
+            "type": "array",
+            "description": "List some keywords pertaining to this skill",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. HTML"
+            }
+          }
+        }
+      }
+    },
+    "languages": {
+      "type": "array",
+      "description": "List any other languages you speak",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "e.g. English, Spanish"
+          },
+          "fluency": {
+            "type": "string",
+            "description": "e.g. Fluent, Beginner"
+          }
+        }
+      }
+    },
+    "interests": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Philosophy"
+          },
+          "keywords": {
+            "type": "array",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Friedrich Nietzsche"
+            }
+          }
+        }
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "List references you have received",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Timothy Cook"
+          },
+          "reference": {
+            "type": "string",
+            "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to latest version of this document"
+        }
+      },
+      "description": "The schema version and any other tooling configuration lives here"
+    }
+  }
 }


### PR DESCRIPTION
Right now resume.json uses 2 spaces for indentation while schema.json mostly tabs (with some spaces mixed in). To get rid of this inconsistency I've formatted schema.json with 2 spaces as well.

This fix will probably break currently outstanding merges for pull requests. So it might be a hassle to switch right now, but it will solve any white-space issues later on.