### PR TITLE
Use ZSchema 3.x while preserving 2.4.x return structure

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -8,11 +8,16 @@ var path = require('path');
 var schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'schema.json'), 'utf8'));
 
 function validate(resumeJson, callback) {
-  ZSchema.validate(resumeJson, schema)
-    .then(function(report) {
-      callback(null, report);
-    })
-    .catch(callback);
+  // Callers expect z-schema 2.4.x report object
+  var callbackWrapper = function(err, valid) {
+    if(err) {
+      callback(err)
+    } else {
+      callback(null, {valid: valid});
+    }
+  }
+
+  new ZSchema().validate(resumeJson, schema, callbackWrapper);
 }
 
 module.exports = {


### PR DESCRIPTION
In order to use ZSchema 3.x, some small changes need to be made:

- `require('z-schema')` is no longer used directly, you need to instantiate it: `new ZSchema()`
- ZSchema 3.x takes a callback and returns validity directly as a boolean, it needs to be wrapped to preserve the external behaviour