### PR TITLE
Add location to work entries.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -97,6 +97,10 @@
             "type": "string",
             "description": "e.g. Facebook"
           },
+          "location": {
+            "type": "string",
+            "description": "e.g. Menlo Park, CA"
+          },
           "description": {
             "type": "string",
             "description": "e.g. Social Media Company"


### PR DESCRIPTION
I'm working on a project that takes jsonresume data and creates latex pdfs and I noticed one field I've wanted to add consistently is a location for job entries. This pull request adds that field.