### PR TITLE
add location to work entry in complete example

### DIFF
--- a/examples/valid/complete.json
+++ b/examples/valid/complete.json
@@ -30,6 +30,7 @@
   "work": [
     {
       "name": "Pied Piper",
+      "location": "Palo Alto, CA",
       "description": "Awesome compression company",
       "position": "CEO/President",
       "url": "http://piedpiper.example.com",


### PR DESCRIPTION
The [latest commit](https://github.com/jsonresume/resume-schema/commit/675972c31ed9a929fab85dadcb65d7e6d5d4d4d2) seems to show that a `work` entry can now have a `location` string inside it, so just wanted to update the example as I had been trying to figure out if this field existed.