### PR TITLE
change name key under work to company

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -93,7 +93,7 @@
         "type": "object",
         "additionalProperties": true,
         "properties": {
-          "name": {
+          "company": {
             "type": "string",
             "description": "e.g. Facebook"
           },


### PR DESCRIPTION
Change official schema for work company name to be `company` instead of `name`. See Issue #331 