### PR TITLE
proxy args directly to ZSchema instance, allowing for choice between callback, promise, and sync apis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -636,9 +636,9 @@
       "dev": true
     },
     "validator": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
-      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
+      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -653,14 +653,14 @@
       "dev": true
     },
     "z-schema": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.2.tgz",
-      "integrity": "sha512-7bGR7LohxSdlK1EOdvA/OHksvKGE4jTLSjd8dBj9YKT0S43N9pdMZ0Z7GZt9mHrBFhbNTRh3Ky6Eu2MHsPJe8g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
+      "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
       "requires": {
         "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "validator": "^11.0.0"
+        "validator": "^12.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "validator.js"
   ],
   "dependencies": {
-    "z-schema": "^4.2.2"
+    "z-schema": "^4.2.3"
   },
   "devDependencies": {
     "tap-spec": "^5.0.0",

--- a/validator.js
+++ b/validator.js
@@ -2,19 +2,9 @@
 var ZSchema = require('z-schema');
 var schema = require('./schema');
 
-function validate(resumeJson, callback) {
-  var callbackWrapper = function(err, valid) {
-    if(err) {
-      callback(err)
-    } else {
-      callback(null, {valid: valid});
-    }
-  }
-
-  new ZSchema().validate(resumeJson, schema, callbackWrapper);
-}
+const zs = new ZSchema();
 
 module.exports = {
-  validate: validate,
+  validate: (resumeJson, ...args) => zs.validate(resumeJson, schema, ...args),
   schema: schema
 };


### PR DESCRIPTION
This exposes zschema's promise and sync interface and preserves the existing cb interface.

The interesting change is in [`validator.js`](https://github.com/jsonresume/resume-schema/pull/356/files#diff-56729df6fb853f60216e1b2d64bccf91)