### PR TITLE
Use GH Actions for CI/CD

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,0 +1,32 @@
+name: Latest
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [10, 12]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache-
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm t

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [10, 12]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache-
+      - name: Verify
+        run: |
+          npm ci
+          npm t
+  npm:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Publish
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+        npm publish --access public


### PR DESCRIPTION
The following replaces TravisCI for CI, and adds a CD workflow that publishes to NPM.

- CI - triggers when on every push for every branch
- CD - triggers when a new tag is published to the origin

Tagging is done via the `npm version [version]` command

**Requirements**

The CD workflow requires a `NPM_AUTH_TOKEN` to be set in the project secrets. The token needs to be created on NPM from an account with publish access to the `jsonresume` org.