### PR TITLE
Allow 'endDate' to be null

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -120,7 +120,7 @@
             "format": "date"
           },
           "endDate": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "e.g. 2012-06-29",
             "format": "date"
           },
@@ -166,7 +166,7 @@
             "format": "date"
           },
           "endDate": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "e.g. 2012-06-29",
             "format": "date"
           },
@@ -211,7 +211,7 @@
             "format": "date"
           },
           "endDate": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "e.g. 2012-06-29",
             "format": "date"
           },
@@ -418,7 +418,7 @@
             "format": "date"
           },
           "endDate": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "e.g. 2012-06-29",
             "format": "date"
           },

--- a/test/__test__/education.json
+++ b/test/__test__/education.json
@@ -68,10 +68,17 @@
       }
     ]
   },
-  "endDateInvalid": {
+  "endDateNull": {
     "education": [
       {
         "endDate": null
+      }
+    ]
+  },
+  "endDateInvalid": {
+    "education": [
+      {
+        "endDate": 0
       }
     ]
   },

--- a/test/__test__/projects.json
+++ b/test/__test__/projects.json
@@ -118,10 +118,17 @@
       }
     ]
   },
-  "endDateInvalid": {
+  "endDateNull": {
     "projects": [
       {
         "endDate": null
+      }
+    ]
+  },
+  "endDateInvalid": {
+    "projects": [
+      {
+        "endDate": 0
       }
     ]
   },

--- a/test/__test__/volunteer.json
+++ b/test/__test__/volunteer.json
@@ -68,10 +68,17 @@
       }
     ]
   },
-  "endDateInvalid": {
+  "endDateNull": {
     "volunteer": [
       {
         "endDate": null
+      }
+    ]
+  },
+  "endDateInvalid": {
+    "volunteer": [
+      {
+        "endDate": 0
       }
     ]
   },

--- a/test/__test__/work.json
+++ b/test/__test__/work.json
@@ -96,10 +96,17 @@
       }
     ]
   },
-  "endDateInvalid": {
+  "endDateNull": {
     "work": [
       {
         "endDate": null
+      }
+    ]
+  },
+  "endDateInvalid": {
+    "work": [
+      {
+        "endDate": 0
       }
     ]
   },

--- a/test/education.spec.js
+++ b/test/education.spec.js
@@ -90,6 +90,14 @@ test('education[].endDate - valid', (t) => {
   t.end();
 });
 
+test('education[].endDate - null', (t) => {
+  validate(fixtures.endDateNull, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
 test('education[].endDate - invalid', (t) => {
   validate(fixtures.endDateInvalid, (err, valid) => {
     t.notEqual(err, null, 'err should contain an error');

--- a/test/projects.spec.js
+++ b/test/projects.spec.js
@@ -138,6 +138,14 @@ test('projects[].endDate - valid', (t) => {
   t.end();
 });
 
+test('projects[].endDate - null', (t) => {
+  validate(fixtures.endDateNull, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
 test('projects[].endDate - invalid', (t) => {
   validate(fixtures.endDateInvalid, (err, valid) => {
     t.notEqual(err, null, 'err should contain an error');

--- a/test/volunteer.spec.js
+++ b/test/volunteer.spec.js
@@ -90,6 +90,14 @@ test('volunteer[].endDate - valid', (t) => {
   t.end();
 });
 
+test('volunteer[].endDate - null', (t) => {
+  validate(fixtures.endDateNull, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
 test('volunteer[].endDate - invalid', (t) => {
   validate(fixtures.endDateInvalid, (err, valid) => {
     t.notEqual(err, null, 'err should contain an error');

--- a/test/work.spec.js
+++ b/test/work.spec.js
@@ -122,6 +122,14 @@ test('work[].endDate - valid', (t) => {
   t.end();
 });
 
+test('work[].endDate - null', (t) => {
+  validate(fixtures.endDateNull, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
 test('work[].endDate - invalid', (t) => {
   validate(fixtures.endDateInvalid, (err, valid) => {
     t.notEqual(err, null, 'err should contain an error');


### PR DESCRIPTION
Change
--------
- Allow `endDate` to be `null`, which seems the norm to represent "Present", but fails schema check in the original schema.

Accept/Reject at your own discretion 😄 