### PR TITLE
feat: add education[].summary

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -223,6 +223,10 @@
             "type": "string",
             "description": "grade point average, e.g. 3.67/4.0"
           },
+          "summary": {
+            "type": "string",
+            "description": "a short summary of your studies, e.g. Thesis"
+          },
           "courses": {
             "type": "array",
             "description": "List notable courses/subjects",

--- a/test/__test__/education.json
+++ b/test/__test__/education.json
@@ -117,6 +117,20 @@
       }
     ]
   },
+  "summaryValid": {
+    "education": [
+      {
+        "summary": "I wrote an awesome Master's Thesis."
+      }
+    ]
+  },
+  "summaryInvalid": {
+    "education": [
+      {
+        "summary": null
+      }
+    ]
+  },
   "coursesValid": {
     "education": [
       {

--- a/test/education.spec.js
+++ b/test/education.spec.js
@@ -146,6 +146,22 @@ test('education[].score - invalid', (t) => {
   t.end();
 });
 
+test('education[].summary - valid', (t) => {
+  validate(fixtures.summaryValid, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('education[].summary - invalid', (t) => {
+  validate(fixtures.summaryInvalid, (err, valid) => {
+    t.notEqual(err, null, 'err should contain an error');
+    t.false(valid, 'valid is false');
+  });
+  t.end();
+});
+
 test('education[].courses - valid', (t) => {
   validate(fixtures.coursesValid, (err, valid) => {
     t.equal(err, null, 'err should be null');


### PR DESCRIPTION
fix jsonresume/jsonresume.org#292

I was unsure about `summary`, I thought `description` also. I decided to go with `summary` because `Education` is something quite universal: `area`, `studyType`, and `Institution` describes almost everything; the only thing I miss about it is a field to describe briefly my Master's Thesis. Also, in the `Work` section, `description` is about the company and `summary` is about the job.

But I can change to `description` if you prefer.

Should I amend the `sample.resume.json` with this field?