### PR TITLE
Add DOI field to publications

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -317,6 +317,10 @@
           "summary": {
             "type": "string",
             "description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+          },
+          "doi":{
+            "type": "string",
+            "description": "The DOI of the publication"
           }
         }
       }


### PR DESCRIPTION
This adds a field to provide the [doi](https://www.doi.org/) of a publication, allowing for  unique  identification of the publication.