### PR TITLE
Fixed validation code sample in readme by adding callback argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ More likely
 var fs = require("fs");
 var resumeSchema = require("resume-schema");
 var resumeObject = JSON.parse(fs.readFileSync("resume.json", "utf8"));
-resumeSchema.validate(resumeObject);
+resumeSchema.validate(
+  resumeObject,
+  function (err) {
+    console.error("The resume was invalid:", err);
+  }
+);
 ```
 
 The JSON Resume schema is available from:


### PR DESCRIPTION
The current version of the sample in question doesn't work as is. I made the most straightforward change that would fix it (following the preceding example). Another option could be to make the callback optional altogether.