### PR TITLE
Fix `sample.resume.json` canonical url

### DIFF
--- a/sample.resume.json
+++ b/sample.resume.json
@@ -154,7 +154,7 @@
     }
   ],
   "meta": {
-    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/resume.json",
+    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/sample.resume.json",
     "version": "v1.0.0",
     "lastModified": "2017-12-24T15:53:00"
   }


### PR DESCRIPTION
The sample resume was first added as `./resume.json` in 7886712c227a4798671c8e55cca8269c798af6c9. Since then it has been renamed to  `./examples/valid/complete.json` in 01c7809792fd102feb3e7f72b86b9b5ac6c4970b and now  `./sample.resume.json` in f856767c0782a442c0a5b694c30122d78b20c600.

The `meta.canonical` url has never been updated to reflect this renaming