### PR TITLE
Changed meta info to have the canonical URL with current sample filename

### DIFF
--- a/sample.resume.json
+++ b/sample.resume.json
@@ -154,7 +154,7 @@
     }
   ],
   "meta": {
-    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/resume.json",
+    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/sample.resume.json",
     "version": "v1.0.0",
     "lastModified": "2017-12-24T15:53:00"
   }


### PR DESCRIPTION
Previous file was renamed resulting in a 404; change now reflects the live file's URL.