### PR TITLE
fix: change certificates date format to ISO8601

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resume-schema",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "JSON Resume Schema",
   "main": "validator.js",
   "scripts": {

--- a/schema.json
+++ b/schema.json
@@ -274,9 +274,7 @@
             "description": "e.g. Certified Kubernetes Administrator"
           },
           "date": {
-            "type": "string",
-            "description": "e.g. 1989-06-12",
-            "format": "date"
+            "$ref": "#/definitions/iso8601"
           },
           "url": {
             "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "iso8601": {
       "type": "string",
-      "description": "e.g. 2014-06-29",
+      "description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
       "pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
     }
   },

--- a/test/__test__/certificates.json
+++ b/test/__test__/certificates.json
@@ -1,0 +1,79 @@
+
+{
+  "certificatesValid": {
+    "certificates": []
+  },
+  "certificatesInvalid": {
+    "certificates": null
+  },
+  "nameValid": {
+    "certificates": [
+      {
+        "name": "Software Development Technician Level 3"
+      }
+    ]
+  },
+  "nameInvalid": {
+    "certificates": [
+      {
+        "name": null
+      }
+    ]
+  },
+  "dateValid": {
+    "certificates": [
+      {
+        "date": "2019-05-20"
+      }
+    ]
+  },
+  "dateValid2": {
+    "certificates": [
+      {
+        "date": "2019-05"
+      }
+    ]
+  },
+  "dateValid3": {
+    "certificates": [
+      {
+        "date": "2019"
+      }
+    ]
+  },
+  "dateInvalid": {
+    "certificates": [
+      {
+        "date": null
+      }
+    ]
+  },
+  "urlValid": {
+    "certificates": [
+      {
+        "url": "https://yewtu.be/watch?v=dQw4w9WgXcQ"
+      }
+    ]
+  },
+  "urlInvalid": {
+    "certificates": [
+      {
+        "url": null
+      }
+    ]
+  },
+  "issuerValid": {
+    "certificates": [
+      {
+        "issuer": "Institute for Apprenticeships"
+      }
+    ]
+  },
+  "issuerInvalid": {
+    "certificates": [
+      {
+        "issuer": null
+      }
+    ]
+  }
+}

--- a/test/certificates.spec.js
+++ b/test/certificates.spec.js
@@ -1,0 +1,99 @@
+var test = require('tape');
+var { validate } = require('../validator');
+const fixtures = require('./__test__/certificates.json');
+
+test('certificates - valid', (t) => {
+  validate(fixtures.certificatesValid, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('certificates - invalid', (t) => {
+  validate(fixtures.certificatesInvalid, (err, valid) => {
+    t.notEqual(err, null, 'err should contain an error');
+    t.false(valid, 'valid is false');
+  });
+  t.end();
+});
+
+test('certificates[].name - valid', (t) => {
+  validate(fixtures.nameValid, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('certificates[].name - invalid', (t) => {
+  validate(fixtures.nameInvalid, (err, valid) => {
+    t.notEqual(err, null, 'err should contain an error');
+    t.false(valid, 'valid is false');
+  });
+  t.end();
+});
+
+test('certificates[].date - valid [YYYY-MM-DD]', (t) => {
+  validate(fixtures.dateValid, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('certificates[].date - valid [YYYY-MM]', (t) => {
+  validate(fixtures.dateValid2, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('certificates[].date - valid [YYYY]', (t) => {
+  validate(fixtures.dateValid3, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('certificates[].date - invalid', (t) => {
+  validate(fixtures.dateInvalid, (err, valid) => {
+    t.notEqual(err, null, 'err should contain an error');
+    t.false(valid, 'valid is false');
+  });
+  t.end();
+});
+
+test('certificates[].url - valid', (t) => {
+  validate(fixtures.urlValid, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('certificates[].url - invalid', (t) => {
+  validate(fixtures.urlInvalid, (err, valid) => {
+    t.notEqual(err, null, 'err should contain an error');
+    t.false(valid, 'valid is false');
+  });
+  t.end();
+});
+
+test('certificates[].issuer - valid', (t) => {
+  validate(fixtures.issuerValid, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('certificates[].issuer - invalid', (t) => {
+  validate(fixtures.issuerInvalid, (err, valid) => {
+    t.notEqual(err, null, 'err should contain an error');
+    t.false(valid, 'valid is false');
+  });
+  t.end();
+});


### PR DESCRIPTION
This PR modifies the `date` property of the `certificates` object to use the ISO8601 reference defined in the schema.

These changes resolve #412 and #448.