### PR TITLE
chore: correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "git://github.com/jsonresume/resume-schema.git"
   },
-  "license": "BSD-2-Clause",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/jsonresume/resume-schema/issues"
   },


### PR DESCRIPTION
We include a LICENSE file in the repository, but the license specified in package.json doesn't match. This just corrects it.