### PR TITLE
fix: add scheme to sample project URL

### DIFF
--- a/sample.resume.json
+++ b/sample.resume.json
@@ -145,7 +145,7 @@
       ],
       "startDate": "2016-08-24",
       "endDate": "2016-08-24",
-      "url": "missdirection.example.com",
+      "url": "http://missdirection.example.com",
       "roles": [
         "Team lead", "Designer"
       ],


### PR DESCRIPTION
Add `http` scheme to sample project URL, fixing the following JSON schema validation error:

![](https://github.com/jsonresume/resume-schema/assets/874370/ee1fe9a7-74a1-4daf-900b-69aff9c06312)
