### PR TITLE
fix: pin sample resume canonical URL version

### DIFF
--- a/sample.resume.json
+++ b/sample.resume.json
@@ -154,7 +154,7 @@
     }
   ],
   "meta": {
-    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/sample.resume.json",
+    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/sample.resume.json",
     "version": "v1.0.0",
     "lastModified": "2017-12-24T15:53:00"
   }


### PR DESCRIPTION
Specify the release version in the sample resume's canonical URL, to ensure that contents match.

Relates to #470.