### PR TITLE
schema: support multiple positions at a single company

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -116,6 +116,27 @@
             "type": "string",
             "description": "e.g. Social Media Company"
           },
+          "positions": {
+            "type": "array",
+            "description": "Define multiple positions at the same company.",
+            "additionalItems": false,
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "description": "e.g. Software Engineer"
+                },
+                "startDate": {
+                  "$ref": "#/definitions/iso8601"
+                },
+                "endDate": {
+                  "$ref": "#/definitions/iso8601"
+                }
+              }
+            }
+          },
           "position": {
             "type": "string",
             "description": "e.g. Software Engineer"

--- a/test/__test__/work.json
+++ b/test/__test__/work.json
@@ -47,6 +47,27 @@
       }
     ]
   },
+  "positionsValid": {
+    "work": [
+      {
+        "positions": [
+          {
+            "title": "Cat Herder",
+            "startDate": "2014-02-12",
+            "endDate": "2014-02-13"
+          },
+          {}
+        ]
+      }
+    ]
+  },
+  "positionsInvalid": {
+    "work": [
+      {
+        "positions": null
+      }
+    ]
+  },
   "positionValid": {
     "work": [
       {

--- a/test/work.spec.js
+++ b/test/work.spec.js
@@ -82,6 +82,22 @@ test('work[].position - invalid', (t) => {
   t.end();
 });
 
+test('work[].positions - valid', (t) => {
+  validate(fixtures.positionsValid, (err, valid) => {
+    t.equal(err, null, 'err should be null');
+    t.true(valid, 'valid is true');
+  });
+  t.end();
+});
+
+test('work[].positions - invalid', (t) => {
+  validate(fixtures.positionsInvalid, (err, valid) => {
+    t.notEqual(err, null, 'err should contain an error');
+    t.false(valid, 'valid is false');
+  });
+  t.end();
+});
+
 test('work[].url - valid', (t) => {
   validate(fixtures.urlValid, (err, valid) => {
     t.equal(err, null, 'err should be null');


### PR DESCRIPTION
I am currently migrating from my own bespoke resume data format to jsonresume and have run into a blocker in the sense that my current resume typesetting document can display more than one title and a start/end date range for that title for each work section. I feel this is important to show the trajectory of promotions through one's career (if desired).

This proposed solution maintains backwards compatibility with what was in place before by simply adding a new pluralized "positions" section and leaving the old "position" section as-is.
