### PR TITLE
fix: schema spacing

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-" $id": "http://example.com/example.json",
+  "$id": "http://example.com/example.json",
   "additionalProperties": true,
   "definitions": {
     "iso8601": {


### PR DESCRIPTION
Noticed that there is a spacing issue and the `$id` property has a leading space.