### PR TITLE
Fix: Sample Resume does not conform to schema

### DIFF
--- a/sample.resume.json
+++ b/sample.resume.json
@@ -19,7 +19,7 @@
       {
         "network": "Twitter",
         "username": "neutralthoughts",
-        "url": ""
+        "url": "https://www.twitter.com"
       },
       {
         "network": "SoundCloud",


### PR DESCRIPTION
This fixes an issue where the sample resume failed to conform to the schema because an empty string is not a valid URI. 

For privacy/spam considerations, I chose not to use an actual Twitter profile, as that might be problematic. Instead, I just used the Twitter front page. 