### PR TITLE
fix: region description for location in job-schema

### DIFF
--- a/job-schema.json
+++ b/job-schema.json
@@ -48,7 +48,7 @@
           },
           "region": {
             "type": "string",
-            "description": "The general region where you live. Can be a US state, or a province, for instance."
+            "description": "The general region of the job. Can be a US state, or a province, for instance."
           }
         }
       },


### PR DESCRIPTION
Changed description of region to make sense for job description schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description for the "region" field in job location details to clarify that it refers to the job's region rather than the user's.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->