### PR TITLE
add cross-ref to projects on job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+merged.json

--- a/job-schema.json
+++ b/job-schema.json
@@ -2,6 +2,7 @@
 	"$schema": "https://json-schema.org/draft-07/schema",
 	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/job-schema.json",
 	"title": "Job Description Schema",
+	"description": "This schema is for defining a job description",
 	"version": "2.0.0",
 	"type": "object",
 	"additionalProperties": false,
@@ -54,15 +55,6 @@
 			"items": {
 				"type": "string",
 				"description": "e.g. Build out a new API for our customer base."
-			}
-		},
-		"crossReferencedProjects": {
-			"type": "array",
-			"description": "A list of the IDs of the projects that are cross-referenced with this job. Particularly useful for consulting roles.",
-			"additionalItems": false,
-			"items": {
-				"type": "string",
-				"description": "The ID number of the project for cross-referencing purposes."
 			}
 		},
 		"qualifications": {

--- a/job-schema.json
+++ b/job-schema.json
@@ -1,6 +1,6 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/job-schema.json#",
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/job-schema.json",
 	"title": "Job Description Schema",
 	"version": "2.0.0",
 	"type": "object",

--- a/job-schema.json
+++ b/job-schema.json
@@ -103,24 +103,10 @@
 			}
 		},
 		"meta": {
-			"type": "object",
-			"description": "The schema version and any other tooling configuration lives here.",
-			"additionalProperties": false,
-			"properties": {
-				"canonical": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to latest version of this document.",
-					"format": "uri"
-				},
-				"version": {
-					"type": "string",
-					"description": "A version field which follows semver - e.g. v1.0.0."
-				},
-				"lastModified": {
-					"type": "string",
-					"description": "Using ISO 8601 with 'YYYY-MM-DDThh:mm:ss'."
-				}
-			}
+			"$ref": "types.json#/definitions/meta"
 		}
-	}
+	},
+	"required": [
+		"meta"
+	]
 }

--- a/job-schema.json
+++ b/job-schema.json
@@ -30,7 +30,15 @@
 		},
 		"type": {
 			"type": "string",
-			"description": "The type of job this is, e.g. Full-time, part-time, contract, etc."
+			"description": "The type of job this is, e.g. Full-time, part-time, contract, etc.",
+			"enum": [
+				"Part-Time",
+				"Full-Time",
+				"Seasonal",
+				"On-Demand",
+				"Contract",
+				"Unspecified"
+			]
 		},
 		"date": {
 			"description": "The date the job was posted in ISO8601 format.",

--- a/job-schema.json
+++ b/job-schema.json
@@ -91,13 +91,8 @@
 						"$ref": "types.json#/definitions/masteryLevel"
 					},
 					"keywords": {
-						"type": "array",
-						"description": "Keywords pertaining to this skill.",
-						"additionalItems": false,
-						"items": {
-							"type": "string",
-							"description": "e.g. HTML"
-						}
+						"description": "A list of keywords pertaining to this skill.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}

--- a/job-schema.json
+++ b/job-schema.json
@@ -27,28 +27,8 @@
 			"description": "A short description about the job."
 		},
 		"location": {
-			"type": "object",
 			"description": "Where the job is located. For fully remote jobs, simply fill in the country code of the position and leave the other fields as `null`.",
-			"additionalProperties": false,
-			"properties": {
-				"address": {
-					"type": "string"
-				},
-				"postalCode": {
-					"type": "string"
-				},
-				"city": {
-					"type": "string"
-				},
-				"countryCode": {
-					"type": "string",
-					"description": "Code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN."
-				},
-				"region": {
-					"type": "string",
-					"description": "The general region where the job is. Can be a US state or a province."
-				}
-			}
+			"$ref": "types.json#/definitions/location"
 		},
 		"remote": {
 			"type": "string",

--- a/job-schema.json
+++ b/job-schema.json
@@ -74,6 +74,10 @@
 				"description": "The optional qualification, e.g. 'undergraduate degree'."
 			}
 		},
+		"keywords": {
+			"description": "A list of keywords pertaining to the listing; sourced from the qualifications (required and optional), job description, and responsibilities.",
+			"$ref": "types.json#/definitions/keywords"
+		},
 		"skills": {
 			"type": "array",
 			"description": "A list of the skills utilized while doing work for the job.",
@@ -91,7 +95,7 @@
 						"$ref": "types.json#/definitions/masteryLevel"
 					},
 					"keywords": {
-						"description": "A list of keywords pertaining to this skill.",
+						"description": "A list of keywords pertaining to this specific skill.",
 						"$ref": "types.json#/definitions/keywords"
 					}
 				}

--- a/job-schema.json
+++ b/job-schema.json
@@ -1,28 +1,10 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/job-schema.json",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/job-schema.json#",
 	"title": "Job Description Schema",
 	"version": "2.0.0",
 	"type": "object",
 	"additionalProperties": false,
-	"definitions": {
-		"iso8601": {
-			"type": "string",
-			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-0.",
-			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
-		},
-		"masteryLevel": {
-			"type": "string",
-			"description": "One of five mastery levels for a particular skill.",
-			"enum": [
-				"Novice",
-				"Intermediate",
-				"Advanced",
-				"Expert",
-				"Master"
-			]
-		}
-	},
 	"properties": {
 		"title": {
 			"type": "string",
@@ -33,20 +15,12 @@
 			"description": "The company offering the role, e.g. 'Microsoft'."
 		},
 		"type": {
-			"type": "string",
 			"description": "The type of job this is, e.g. Full-time, part-time, contract, etc.",
-			"enum": [
-				"Part-Time",
-				"Full-Time",
-				"Seasonal",
-				"On-Demand",
-				"Contract",
-				"Unspecified"
-			]
+			"$ref": "types.json#/definitions/jobType"
 		},
 		"date": {
 			"description": "The date the job was posted in ISO8601 format.",
-			"$ref": "#/definitions/iso8601"
+			"$ref": "types.json#/definitions/iso8601"
 		},
 		"description": {
 			"type": "string",
@@ -90,18 +64,8 @@
 			"description": "The expected salary or range of salaries plus the base time unit, e.g. $100,000/yearly, $5,000 - $6,000/monthly, $25/hourly."
 		},
 		"experience": {
-			"type": "string",
 			"description": "The experience level required for the job, e.g. 'Senior', 'Junior', 'Mid-level'.",
-			"enum": [
-				"Internship",
-				"Entry-level",
-				"Junior",
-				"Mid-level",
-				"Senior",
-				"Lead",
-				"Director",
-				"Executive"
-			]
+			"$ref": "types.json#/definitions/experienceLevel"
 		},
 		"responsibilities": {
 			"type": "array",
@@ -144,7 +108,7 @@
 					},
 					"level": {
 						"description": "The mastery level of the skill.",
-						"$ref": "#/definitions/masteryLevel"
+						"$ref": "types.json#/definitions/masteryLevel"
 					},
 					"keywords": {
 						"type": "array",

--- a/job-schema.json
+++ b/job-schema.json
@@ -1,40 +1,52 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
-	"additionalProperties": true,
+	"additionalProperties": false,
 	"definitions": {
 		"iso8601": {
 			"type": "string",
-			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
+			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-0.",
 			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+		},
+		"masteryLevel": {
+			"type": "string",
+			"description": "One of five mastery levels for a particular skill.",
+			"enum": [
+				"Novice",
+				"Intermediate",
+				"Advanced",
+				"Expert",
+				"Master"
+			]
 		}
 	},
 	"properties": {
 		"title": {
 			"type": "string",
-			"description": "e.g. Web Developer"
+			"description": "The name of the job, e.g. 'Web Developer'."
 		},
 		"company": {
 			"type": "string",
-			"description": "Microsoft"
+			"description": "The company offering the role, e.g. 'Microsoft'."
 		},
 		"type": {
 			"type": "string",
-			"description": "Full-time, part-time, contract, etc."
+			"description": "The type of job this is, e.g. Full-time, part-time, contract, etc."
 		},
 		"date": {
+			"description": "The date the job was posted in ISO8601 format.",
 			"$ref": "#/definitions/iso8601"
 		},
 		"description": {
 			"type": "string",
-			"description": "Write a short description about the job"
+			"description": "A short description about the job."
 		},
 		"location": {
 			"type": "object",
-			"additionalProperties": true,
+			"description": "Where the job is located. For fully remote jobs, simply fill in the country code of the position and leave the other fields as `null`.",
+			"additionalProperties": false,
 			"properties": {
 				"address": {
-					"type": "string",
-					"description": "To add multiple address lines, use \\n. For example, 1234 Glücklichkeit Straße\\nHinterhaus 5. Etage li."
+					"type": "string"
 				},
 				"postalCode": {
 					"type": "string"
@@ -44,17 +56,17 @@
 				},
 				"countryCode": {
 					"type": "string",
-					"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+					"description": "Code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN."
 				},
 				"region": {
 					"type": "string",
-					"description": "The general region where you live. Can be a US state, or a province, for instance."
+					"description": "The general region where the job is. Can be a US state or a province."
 				}
 			}
 		},
 		"remote": {
 			"type": "string",
-			"description": "the level of remote work available",
+			"description": "The level of remote work available, where 'Full' is fully online and 'None' is strictly in-person.",
 			"enum": [
 				"Full",
 				"Hybrid",
@@ -63,15 +75,25 @@
 		},
 		"salary": {
 			"type": "string",
-			"description": "100000"
+			"description": "The expected salary or range of salaries plus the base time unit, e.g. $100,000/yearly, $5,000 - $6,000/monthly, $25/hourly."
 		},
 		"experience": {
 			"type": "string",
-			"description": "Senior or Junior or Mid-level"
+			"description": "The experience level required for the job, e.g. 'Senior', 'Junior', 'Mid-level'.",
+			"enum": [
+				"Internship",
+				"Entry-level",
+				"Junior",
+				"Mid-level",
+				"Senior",
+				"Lead",
+				"Director",
+				"Executive"
+			]
 		},
 		"responsibilities": {
 			"type": "array",
-			"description": "what the job entails",
+			"description": "What the job entails.",
 			"additionalItems": false,
 			"items": {
 				"type": "string",
@@ -80,32 +102,41 @@
 		},
 		"qualifications": {
 			"type": "array",
-			"description": "List out your qualifications",
+			"description": "A list of the qualifications that are required for this position.",
 			"additionalItems": false,
 			"items": {
 				"type": "string",
-				"description": "undergraduate degree, etc.  "
+				"description": "The required qualification, e.g. 'undergraduate degree'."
+			}
+		},
+		"optionalQualifications": {
+			"type": "array",
+			"description": "A list of the qualifications that are optional for this position.",
+			"additionalItems": false,
+			"items": {
+				"type": "string",
+				"description": "The optional qualification, e.g. 'undergraduate degree'."
 			}
 		},
 		"skills": {
 			"type": "array",
-			"description": "List out your professional skill-set",
+			"description": "A list of the skills utilized while doing work for the job.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
-						"description": "e.g. Web Development"
+						"description": "The name of the skill, e.g. 'Web Development'."
 					},
 					"level": {
-						"type": "string",
-						"description": "e.g. Master"
+						"description": "The mastery level of the skill.",
+						"$ref": "#/definitions/masteryLevel"
 					},
 					"keywords": {
 						"type": "array",
-						"description": "List some keywords pertaining to this skill",
+						"description": "Keywords pertaining to this skill.",
 						"additionalItems": false,
 						"items": {
 							"type": "string",
@@ -117,21 +148,21 @@
 		},
 		"meta": {
 			"type": "object",
-			"description": "The schema version and any other tooling configuration lives here",
-			"additionalProperties": true,
+			"description": "The schema version and any other tooling configuration lives here.",
+			"additionalProperties": false,
 			"properties": {
 				"canonical": {
 					"type": "string",
-					"description": "URL (as per RFC 3986) to latest version of this document",
+					"description": "URL (as per RFC 3986) to latest version of this document.",
 					"format": "uri"
 				},
 				"version": {
 					"type": "string",
-					"description": "A version field which follows semver - e.g. v1.0.0"
+					"description": "A version field which follows semver - e.g. v1.0.0."
 				},
 				"lastModified": {
 					"type": "string",
-					"description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+					"description": "Using ISO 8601 with 'YYYY-MM-DDThh:mm:ss'."
 				}
 			}
 		}

--- a/job-schema.json
+++ b/job-schema.json
@@ -1,141 +1,141 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": true,
-    "definitions": {
-      "iso8601": {
-        "type": "string",
-        "description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
-        "pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
-      }
-    },
-    "properties": {
-      "title": {
-        "type": "string",
-        "description": "e.g. Web Developer"
-      },
-      "company": {
-        "type": "string",
-        "description": "Microsoft"
-      },
-      "type": {
-        "type": "string",
-        "description": "Full-time, part-time, contract, etc."
-      },
-      "date": {
-        "$ref": "#/definitions/iso8601"
-      },
-      "description": {
-        "type": "string",
-        "description": "Write a short description about the job"
-      },
-      "location": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "address": {
-            "type": "string",
-            "description": "To add multiple address lines, use \\n. For example, 1234 Glücklichkeit Straße\\nHinterhaus 5. Etage li."
-          },
-          "postalCode": {
-            "type": "string"
-          },
-          "city": {
-            "type": "string"
-          },
-          "countryCode": {
-            "type": "string",
-            "description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
-          },
-          "region": {
-            "type": "string",
-            "description": "The general region where you live. Can be a US state, or a province, for instance."
-          }
-        }
-      },
-      "remote": {
-        "type": "string",
-        "description": "the level of remote work available",
-        "enum": [
-          "Full",
-          "Hybrid",
-          "None"
-        ]
-      },
-      "salary": {
-        "type": "string",
-        "description": "100000"
-      },
-      "experience": {
-        "type": "string",
-        "description": "Senior or Junior or Mid-level"
-      },
-      "responsibilities": {
-        "type": "array",
-        "description": "what the job entails",
-        "additionalItems": false,
-        "items": {
-          "type": "string",
-          "description": "e.g. Build out a new API for our customer base."
-        }
-      },
-      "qualifications": {
-        "type": "array",
-        "description": "List out your qualifications",
-        "additionalItems": false,
-        "items": {
-          "type": "string",
-          "description": "undergraduate degree, etc.  "
-        }
-      },
-      "skills": {
-        "type": "array",
-        "description": "List out your professional skill-set",
-        "additionalItems": false,
-        "items": {
-          "type": "object",
-          "additionalProperties": true,
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "e.g. Web Development"
-            },
-            "level": {
-              "type": "string",
-              "description": "e.g. Master"
-            },
-            "keywords": {
-              "type": "array",
-              "description": "List some keywords pertaining to this skill",
-              "additionalItems": false,
-              "items": {
-                "type": "string",
-                "description": "e.g. HTML"
-              }
-            }
-          }
-        }
-      },
-      "meta": {
-        "type": "object",
-        "description": "The schema version and any other tooling configuration lives here",
-        "additionalProperties": true,
-        "properties": {
-          "canonical": {
-            "type": "string",
-            "description": "URL (as per RFC 3986) to latest version of this document",
-            "format": "uri"
-          },
-          "version": {
-            "type": "string",
-            "description": "A version field which follows semver - e.g. v1.0.0"
-          },
-          "lastModified": {
-            "type": "string",
-            "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
-          }
-        }
-      }
-    },
-    "title": "Job Description Schema",
-    "type": "object"
-  }
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"additionalProperties": true,
+	"definitions": {
+		"iso8601": {
+			"type": "string",
+			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
+			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+		}
+	},
+	"properties": {
+		"title": {
+			"type": "string",
+			"description": "e.g. Web Developer"
+		},
+		"company": {
+			"type": "string",
+			"description": "Microsoft"
+		},
+		"type": {
+			"type": "string",
+			"description": "Full-time, part-time, contract, etc."
+		},
+		"date": {
+			"$ref": "#/definitions/iso8601"
+		},
+		"description": {
+			"type": "string",
+			"description": "Write a short description about the job"
+		},
+		"location": {
+			"type": "object",
+			"additionalProperties": true,
+			"properties": {
+				"address": {
+					"type": "string",
+					"description": "To add multiple address lines, use \\n. For example, 1234 Glücklichkeit Straße\\nHinterhaus 5. Etage li."
+				},
+				"postalCode": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"countryCode": {
+					"type": "string",
+					"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+				},
+				"region": {
+					"type": "string",
+					"description": "The general region where you live. Can be a US state, or a province, for instance."
+				}
+			}
+		},
+		"remote": {
+			"type": "string",
+			"description": "the level of remote work available",
+			"enum": [
+				"Full",
+				"Hybrid",
+				"None"
+			]
+		},
+		"salary": {
+			"type": "string",
+			"description": "100000"
+		},
+		"experience": {
+			"type": "string",
+			"description": "Senior or Junior or Mid-level"
+		},
+		"responsibilities": {
+			"type": "array",
+			"description": "what the job entails",
+			"additionalItems": false,
+			"items": {
+				"type": "string",
+				"description": "e.g. Build out a new API for our customer base."
+			}
+		},
+		"qualifications": {
+			"type": "array",
+			"description": "List out your qualifications",
+			"additionalItems": false,
+			"items": {
+				"type": "string",
+				"description": "undergraduate degree, etc.  "
+			}
+		},
+		"skills": {
+			"type": "array",
+			"description": "List out your professional skill-set",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. Web Development"
+					},
+					"level": {
+						"type": "string",
+						"description": "e.g. Master"
+					},
+					"keywords": {
+						"type": "array",
+						"description": "List some keywords pertaining to this skill",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. HTML"
+						}
+					}
+				}
+			}
+		},
+		"meta": {
+			"type": "object",
+			"description": "The schema version and any other tooling configuration lives here",
+			"additionalProperties": true,
+			"properties": {
+				"canonical": {
+					"type": "string",
+					"description": "URL (as per RFC 3986) to latest version of this document",
+					"format": "uri"
+				},
+				"version": {
+					"type": "string",
+					"description": "A version field which follows semver - e.g. v1.0.0"
+				},
+				"lastModified": {
+					"type": "string",
+					"description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+				}
+			}
+		}
+	},
+	"title": "Job Description Schema",
+	"type": "object"
+}

--- a/job-schema.json
+++ b/job-schema.json
@@ -1,5 +1,9 @@
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/job-schema.json",
+	"title": "Job Description Schema",
+	"version": "2.0.0",
+	"type": "object",
 	"additionalProperties": false,
 	"definitions": {
 		"iso8601": {
@@ -174,7 +178,5 @@
 				}
 			}
 		}
-	},
-	"title": "Job Description Schema",
-	"type": "object"
+	}
 }

--- a/job-schema.json
+++ b/job-schema.json
@@ -56,6 +56,15 @@
 				"description": "e.g. Build out a new API for our customer base."
 			}
 		},
+		"crossReferencedProjects": {
+			"type": "array",
+			"description": "A list of the IDs of the projects that are cross-referenced with this job. Particularly useful for consulting roles.",
+			"additionalItems": false,
+			"items": {
+				"type": "string",
+				"description": "The ID number of the project for cross-referencing purposes."
+			}
+		},
 		"qualifications": {
 			"type": "array",
 			"description": "A list of the qualifications that are required for this position.",

--- a/keywords-dictionary-schema.json
+++ b/keywords-dictionary-schema.json
@@ -1,0 +1,71 @@
+{
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/keywords-dictionary-schema.json",
+	"title": "Keywords Dictionary Schema",
+	"version": "2.0.0",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"categories": {
+			"type": "object",
+			"description": "Top-level categorization of a keyword, e.g. 'devops', 'saas'.",
+			"patternProperties": {
+				"^[a-zA-Z0-9_-]+$": {
+					"type": "object",
+					"properties": {
+						"displayName": {
+							"type": "string",
+							"description": "The display name of the category, e.g. 'Database', 'Programming Languages'."
+						},
+						"description": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"displayName"
+					],
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"keywordsDictionary": {
+			"type": "object",
+			"description": "Global keyword definitions map with metadata and category assignment.",
+			"patternProperties": {
+				"^[a-zA-Z0-9_-]+$": {
+					"type": "object",
+					"properties": {
+						"displayName": {
+							"type": "string",
+							"description": "The display name of the keyword, e.g. 'JavaScript', 'Amazon AWS'."
+						},
+						"aliases": {
+							"type": "array",
+							"items": {
+								"type": "string",
+								"description": "A list of aliases that can also map to this keyword, e.g. 'jscript', 'amazon_aws'."
+							}
+						},
+						"category": {
+							"type": "string",
+							"description": "Must match a category key from the top-level categories object."
+						}
+					},
+					"required": [
+						"displayName",
+						"category"
+					],
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"meta": {
+			"$ref": "types.json#/definitions/meta"
+		}
+	},
+	"required": [
+		"meta"
+	]
+}

--- a/merge-schemas.py
+++ b/merge-schemas.py
@@ -4,12 +4,23 @@
 # pyright: reportExplicitAny=false
 # pyright: reportUnknownVariableType=false
 
+from dataclasses import dataclass
 from typing import Any
 import json
 import os
 import sys
+import argparse
 
-def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
+__DEFS_KEYNAME_OLD = "definitions"
+__DEFS_KEYNAME_NEW = "$defs"
+
+@dataclass
+class Options:
+	"""Configuration options for schema merging."""
+	use_tabs: bool = True
+	force_defs_syntax: bool = False
+
+def merge_schemas(types_file: str, schema_file: str, force_defs_syntax: bool) -> dict[str, Any]:
 	"""Merge types.json definitions into schema.json, including only used refs."""
 
 	# Load files
@@ -28,11 +39,16 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 		print(f"Error: Schema version mismatch between '{schema_file}' and '{types_file}'", file=sys.stderr)
 		exit(1)
 
-	# Pick the correct key name for definitons (draft-2020-12 uses `$defs` instead of `definitions`)
-	# It is safe to assume the version from either schema file since we just verified equality
-	def_keyname = "definitions"
+	# Pick the correct key name for definitions (draft-2020-12 uses `$defs` instead of `definitions`)
+	def_keyname = __DEFS_KEYNAME_OLD
+	def_out_keyname = __DEFS_KEYNAME_OLD
 	if "draft/2020-12/schema" in types_schema_ver:
-		def_keyname = "$defs"
+		def_keyname = __DEFS_KEYNAME_NEW
+		def_out_keyname = __DEFS_KEYNAME_NEW
+
+	# If forcing the use of $defs, set the out keyname accordingly
+	if force_defs_syntax:
+		def_out_keyname = __DEFS_KEYNAME_NEW
 
 	# Extract ALL definitions from types
 	all_defs: dict[str, Any] = types_schema.get(def_keyname, {})
@@ -65,9 +81,9 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 
 	# Merge ONLY used definitions into schema
 	if def_keyname in schema:
-		del schema[def_keyname]  # type: ignore
+		del schema[def_keyname]
 
-	schema[def_keyname] = used_defs  # type: ignore
+	schema[def_out_keyname] = used_defs
 
 	# Fix all external refs to internal refs
 	def fix_refs(obj: Any) -> Any:
@@ -76,9 +92,9 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 				ref_val = obj["$ref"]
 				if isinstance(ref_val, str):
 					if ref_val.startswith(f"{types_filename}#/{def_keyname}/"):
-						obj["$ref"] = f"#/{def_keyname}/" + ref_val[len(f"{types_filename}#/{def_keyname}/"):]  # type: ignore
+						obj["$ref"] = f"#/{def_out_keyname}/" + ref_val[len(f"{types_filename}#/{def_keyname}/"):]
 			for key, value in obj.items():
-				obj[key] = fix_refs(value)  # type: ignore
+				obj[key] = fix_refs(value)
 			return obj
 
 		elif isinstance(obj, list):
@@ -87,23 +103,55 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 		return obj
 
 	fix_refs(schema)
+
+	# If forcing the use of $defs, correct the version identifier to match; basic replacement, might be better to use patterns instead
+	if force_defs_syntax:
+		schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+
 	return schema
 
 
 ## Main
 if __name__ == "__main__":
-	USE_TABS = True
+	# Setup default options
+	opts = Options()
 
-	# Perform argparsing
-	if len(sys.argv) < 3:
-		print(f"Usage: {sys.argv[0]} TYPES.json SCHEMA.json", file=sys.stderr)
-		sys.exit(1)
+	# Setup argument parser with both positional arguments and optional flags
+	parser = argparse.ArgumentParser(
+		description="Merge types.json definitions into schema.json, including only used refs."
+	)
 
-	# Merge and output
-	schema = merge_schemas(sys.argv[1], sys.argv[2])
+	# Add positional arguments (required)
+	parser.add_argument("types_file", help="Path to the TYPES.json file")
+	parser.add_argument("schema_file", help="Path to the SCHEMA.json file")
+
+	# Add optional flag for tab indentation
+	parser.add_argument(
+		"--use-tabs",
+		action="store_true",
+		help="Use tabs instead of spaces for indentation in output"
+	)
+
+	# Add optional flag for forcing $defs syntax for $refs
+	parser.add_argument(
+		"--force-defs-syntax",
+		action="store_true",
+		help="Force the usage of `$defs` over the old `definitions` syntax"
+	)
+
+	# Parse arguments
+	args = parser.parse_args()
+
+	# Override defaults with command line arguments if provided
+	opts.use_tabs = args.use_tabs or opts.use_tabs
+	opts.force_defs_syntax = args.force_defs_syntax or opts.force_defs_syntax
+
+	# Merge the schemas
+	schema = merge_schemas(args.types_file, args.schema_file, opts.force_defs_syntax)
 	jsons = json.dumps(schema, indent=4)
 
-	if USE_TABS:
-		print(jsons.replace(" " * 4, "\t"))
-	else:
-		print(jsons)
+	# Apply options
+	if opts.use_tabs:
+		jsons = jsons.replace(" " * 4, "\t")
+
+	print(jsons)

--- a/merge-schemas.py
+++ b/merge-schemas.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# pyright: reportAny=false
+# pyright: reportExplicitAny=false
+# pyright: reportUnknownVariableType=false
+
+from typing import Any
+import json
+import os
+import sys
+
+def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
+	"""Merge types.json definitions into schema.json, including only used refs."""
+
+	# Load files
+	with open(types_file) as f:
+		types_schema: dict[str, Any] = json.load(f)
+
+	with open(schema_file) as f:
+		schema: dict[str, Any] = json.load(f)
+
+	types_filename: str = os.path.basename(types_file)
+
+	# Extract ALL definitions from types
+	all_defs: dict[str, Any] = types_schema.get("definitions", {})
+
+	# Find ALL $ref values used in schema
+	used_refs: set[str] = set()
+
+	def collect_refs(obj: Any) -> None:
+		if isinstance(obj, dict):
+			if "$ref" in obj:
+				ref_val = obj["$ref"]
+				if isinstance(ref_val, str):
+					if ref_val.startswith(f"{types_filename}#/definitions/"):
+						def_name: str = ref_val[len(f"{types_filename}#/definitions/"):]
+						used_refs.add(def_name)
+
+			for value in obj.values():
+				collect_refs(value)
+
+		elif isinstance(obj, list):
+			for item in obj:
+				collect_refs(item)
+
+	collect_refs(schema)
+
+	# Filter definitions - ONLY include used ones
+	used_defs: dict[str, Any] = {
+		name: all_defs[name] for name in used_refs if name in all_defs
+	}
+
+	# Merge ONLY used definitions into schema
+	if "definitions" in schema:
+		del schema["definitions"]  # type: ignore
+
+	schema["definitions"] = used_defs  # type: ignore
+
+	# Fix all external refs to internal refs
+	def fix_refs(obj: Any) -> Any:
+		if isinstance(obj, dict):
+			if "$ref" in obj:
+				ref_val = obj["$ref"]
+				if isinstance(ref_val, str):
+					if ref_val.startswith(f"{types_filename}#/definitions/"):
+						obj["$ref"] = "#/definitions/" + ref_val[len(f"{types_filename}#/definitions/"):]  # type: ignore
+			for key, value in obj.items():
+				obj[key] = fix_refs(value)  # type: ignore
+			return obj
+
+		elif isinstance(obj, list):
+			return [fix_refs(item) for item in obj]
+
+		return obj
+
+	fix_refs(schema)
+	return schema
+
+
+## Main
+if __name__ == "__main__":
+	USE_TABS = True
+
+	# Perform argparsing
+	if len(sys.argv) < 3:
+		print(f"Usage: {sys.argv[0]} TYPES.json SCHEMA.json", file=sys.stderr)
+		sys.exit(1)
+
+	# Merge and output
+	schema = merge_schemas(sys.argv[1], sys.argv[2])
+	jsons = json.dumps(schema, indent=4)
+
+	if USE_TABS:
+		print(jsons.replace(" " * 4, "\t"))
+	else:
+		print(jsons)

--- a/merge-schemas.py
+++ b/merge-schemas.py
@@ -21,8 +21,21 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 
 	types_filename: str = os.path.basename(types_file)
 
+	# Get the schema versions between both files and ensure they line up
+	types_schema_ver = str(types_schema.get("$schema", ""))
+	schema_ver = str(schema.get("$schema", ""))
+	if types_schema_ver != schema_ver:
+		print(f"Error: Schema version mismatch between '{schema_file}' and '{types_file}'", file=sys.stderr)
+		exit(1)
+
+	# Pick the correct key name for definitons (draft-2020-12 uses `$defs` instead of `definitions`)
+	# It is safe to assume the version from either schema file since we just verified equality
+	def_keyname = "definitions"
+	if "draft/2020-12/schema" in types_schema_ver:
+		def_keyname = "$defs"
+
 	# Extract ALL definitions from types
-	all_defs: dict[str, Any] = types_schema.get("definitions", {})
+	all_defs: dict[str, Any] = types_schema.get(def_keyname, {})
 
 	# Find ALL $ref values used in schema
 	used_refs: set[str] = set()
@@ -32,8 +45,8 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 			if "$ref" in obj:
 				ref_val = obj["$ref"]
 				if isinstance(ref_val, str):
-					if ref_val.startswith(f"{types_filename}#/definitions/"):
-						def_name: str = ref_val[len(f"{types_filename}#/definitions/"):]
+					if ref_val.startswith(f"{types_filename}#/{def_keyname}/"):
+						def_name: str = ref_val[len(f"{types_filename}#/{def_keyname}/"):]
 						used_refs.add(def_name)
 
 			for value in obj.values():
@@ -51,10 +64,10 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 	}
 
 	# Merge ONLY used definitions into schema
-	if "definitions" in schema:
-		del schema["definitions"]  # type: ignore
+	if def_keyname in schema:
+		del schema[def_keyname]  # type: ignore
 
-	schema["definitions"] = used_defs  # type: ignore
+	schema[def_keyname] = used_defs  # type: ignore
 
 	# Fix all external refs to internal refs
 	def fix_refs(obj: Any) -> Any:
@@ -62,8 +75,8 @@ def merge_schemas(types_file: str, schema_file: str) -> dict[str, Any]:
 			if "$ref" in obj:
 				ref_val = obj["$ref"]
 				if isinstance(ref_val, str):
-					if ref_val.startswith(f"{types_filename}#/definitions/"):
-						obj["$ref"] = "#/definitions/" + ref_val[len(f"{types_filename}#/definitions/"):]  # type: ignore
+					if ref_val.startswith(f"{types_filename}#/{def_keyname}/"):
+						obj["$ref"] = f"#/{def_keyname}/" + ref_val[len(f"{types_filename}#/{def_keyname}/"):]  # type: ignore
 			for key, value in obj.items():
 				obj[key] = fix_refs(value)  # type: ignore
 			return obj

--- a/sample.job.json
+++ b/sample.job.json
@@ -1,8 +1,7 @@
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
 	"title": "Web Developer",
 	"company": "Microsoft",
-	"type": "Full-time",
+	"type": "Full-Time",
 	"date": "2024-07",
 	"description": "We are looking for a skilled Web Developer to join our team. The role involves building and maintaining web applications.",
 	"location": {
@@ -50,7 +49,7 @@
 	],
 	"meta": {
 		"canonical": "http://example.com/jobs/web-developer",
-		"version": "v1.0.0",
-		"lastModified": "2024-07-10T15:00:00"
+		"version": "1.0.0",
+		"lastModified": "2026-02-27T00:00:00.000Z"
 	}
 }

--- a/sample.job.json
+++ b/sample.job.json
@@ -1,57 +1,56 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Web Developer",
-    "company": "Microsoft",
-    "type": "Full-time",
-    "date": "2024-07",
-    "description": "We are looking for a skilled Web Developer to join our team. The role involves building and maintaining web applications.",
-    "location": {
-      "address": "1234 Glücklichkeit Straße\nHinterhaus 5. Etage li.",
-      "postalCode": "10115",
-      "city": "Berlin",
-      "countryCode": "DE",
-      "region": "Berlin"
-    },
-    "remote": "Hybrid",
-    "salary": "100000",
-    "experience": "Mid-level",
-    "responsibilities": [
-      "Develop and maintain web applications",
-      "Collaborate with cross-functional teams",
-      "Ensure the technical feasibility of UI/UX designs",
-      "Optimize applications for maximum speed and scalability"
-    ],
-    "qualifications": [
-      "Bachelor's degree in Computer Science or related field",
-      "3+ years of experience in web development",
-      "Strong understanding of JavaScript, HTML, and CSS"
-    ],
-    "skills": [
-      {
-        "name": "Web Development",
-        "level": "Master",
-        "keywords": [
-          "HTML",
-          "CSS",
-          "JavaScript",
-          "React",
-          "Node.js"
-        ]
-      },
-      {
-        "name": "Database Management",
-        "level": "Intermediate",
-        "keywords": [
-          "SQL",
-          "NoSQL",
-          "MongoDB"
-        ]
-      }
-    ],
-    "meta": {
-      "canonical": "http://example.com/jobs/web-developer",
-      "version": "v1.0.0",
-      "lastModified": "2024-07-10T15:00:00"
-    }
-  }
-  
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Web Developer",
+	"company": "Microsoft",
+	"type": "Full-time",
+	"date": "2024-07",
+	"description": "We are looking for a skilled Web Developer to join our team. The role involves building and maintaining web applications.",
+	"location": {
+		"address": "1234 Glücklichkeit Straße\nHinterhaus 5. Etage li.",
+		"postalCode": "10115",
+		"city": "Berlin",
+		"countryCode": "DE",
+		"region": "Berlin"
+	},
+	"remote": "Hybrid",
+	"salary": "100000",
+	"experience": "Mid-level",
+	"responsibilities": [
+		"Develop and maintain web applications",
+		"Collaborate with cross-functional teams",
+		"Ensure the technical feasibility of UI/UX designs",
+		"Optimize applications for maximum speed and scalability"
+	],
+	"qualifications": [
+		"Bachelor's degree in Computer Science or related field",
+		"3+ years of experience in web development",
+		"Strong understanding of JavaScript, HTML, and CSS"
+	],
+	"skills": [
+		{
+			"name": "Web Development",
+			"level": "Master",
+			"keywords": [
+				"HTML",
+				"CSS",
+				"JavaScript",
+				"React",
+				"Node.js"
+			]
+		},
+		{
+			"name": "Database Management",
+			"level": "Intermediate",
+			"keywords": [
+				"SQL",
+				"NoSQL",
+				"MongoDB"
+			]
+		}
+	],
+	"meta": {
+		"canonical": "http://example.com/jobs/web-developer",
+		"version": "v1.0.0",
+		"lastModified": "2024-07-10T15:00:00"
+	}
+}

--- a/sample.resume.json
+++ b/sample.resume.json
@@ -1,161 +1,164 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
-  "basics": {
-    "name": "Richard Hendriks",
-    "label": "Programmer",
-    "image": "",
-    "email": "richard.hendriks@mail.com",
-    "phone": "(912) 555-4321",
-    "url": "http://richardhendricks.example.com",
-    "summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinal!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
-    "location": {
-      "address": "2712 Broadway St",
-      "postalCode": "CA 94115",
-      "city": "San Francisco",
-      "countryCode": "US",
-      "region": "California"
-    },
-    "profiles": [
-      {
-        "network": "Twitter",
-        "username": "neutralthoughts",
-        "url": "https://www.twitter.com"
-      },
-      {
-        "network": "SoundCloud",
-        "username": "dandymusicnl",
-        "url": "https://soundcloud.example.com/dandymusicnl"
-      }
-    ]
-  },
-  "work": [
-    {
-      "name": "Pied Piper",
-      "location": "Palo Alto, CA",
-      "description": "Awesome compression company",
-      "position": "CEO/President",
-      "url": "http://piedpiper.example.com",
-      "startDate": "2013-12-01",
-      "endDate": "2014-12-01",
-      "summary": "Pied Piper is a multi-platform technology based on a proprietary universal compression algorithm that has consistently fielded high Weisman Scores™ that are not merely competitive, but approach the theoretical limit of lossless compression.",
-      "highlights": [
-        "Build an algorithm for artist to detect if their music was violating copy right infringement laws",
-        "Successfully won Techcrunch Disrupt",
-        "Optimized an algorithm that holds the current world record for Weisman Scores"
-      ]
-    }
-  ],
-  "volunteer": [
-    {
-      "organization": "CoderDojo",
-      "position": "Teacher",
-      "url": "http://coderdojo.example.com/",
-      "startDate": "2012-01-01",
-      "endDate": "2013-01-01",
-      "summary": "Global movement of free coding clubs for young people.",
-      "highlights": [
-        "Awarded 'Teacher of the Month'"
-      ]
-    }
-  ],
-  "education": [
-    {
-      "institution": "University of Oklahoma",
-      "url": "https://www.ou.edu/",
-      "area": "Information Technology",
-      "studyType": "Bachelor",
-      "startDate": "2011-06-01",
-      "endDate": "2014-01-01",
-      "score": "4.0",
-      "courses": [
-        "DB1101 - Basic SQL",
-        "CS2011 - Java Introduction"
-      ]
-    }
-  ],
-  "awards": [
-    {
-      "title": "Digital Compression Pioneer Award",
-      "date": "2014-11-01",
-      "awarder": "Techcrunch",
-      "summary": "There is no spoon."
-    }
-  ],
-  "publications": [
-    {
-      "name": "Video compression for 3d media",
-      "publisher": "Hooli",
-      "releaseDate": "2014-10-01",
-      "url": "http://en.wikipedia.org/wiki/Silicon_Valley_(TV_series)",
-      "summary": "Innovative middle-out compression algorithm that changes the way we store data."
-    }
-  ],
-  "skills": [
-    {
-      "name": "Web Development",
-      "level": "Master",
-      "keywords": [
-        "HTML",
-        "CSS",
-        "Javascript"
-      ]
-    },
-    {
-      "name": "Compression",
-      "level": "Master",
-      "keywords": [
-        "Mpeg",
-        "MP4",
-        "GIF"
-      ]
-    }
-  ],
-  "languages": [
-    {
-      "language": "English",
-      "fluency": "Native speaker"
-    }
-  ],
-  "interests": [
-    {
-      "name": "Wildlife",
-      "keywords": [
-        "Ferrets",
-        "Unicorns"
-      ]
-    }
-  ],
-  "references": [
-    {
-      "name": "Erlich Bachman",
-      "reference": "It is my pleasure to recommend Richard, his performance working as a consultant for Main St. Company proved that he will be a valuable addition to any company."
-    }
-  ],
-  "projects": [
-    {
-      "name": "Miss Direction",
-      "description": "A mapping engine that misguides you",
-      "highlights": [
-        "Won award at AIHacks 2016",
-        "Built by all women team of newbie programmers",
-        "Using modern technologies such as GoogleMaps, Chrome Extension and Javascript"
-      ],
-      "keywords": [
-        "GoogleMaps", "Chrome Extension", "Javascript"
-      ],
-      "startDate": "2016-08-24",
-      "endDate": "2016-08-24",
-      "url": "http://missdirection.example.com",
-      "roles": [
-        "Team lead", "Designer"
-      ],
-      "entity": "Smoogle",
-      "type": "application"
-    }
-  ],
-  "meta": {
-    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/sample.resume.json",
-    "version": "v1.0.0",
-    "lastModified": "2017-12-24T15:53:00"
-  }
+	"$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+	"basics": {
+		"name": "Richard Hendriks",
+		"label": "Programmer",
+		"image": "",
+		"email": "richard.hendriks@mail.com",
+		"phone": "(912) 555-4321",
+		"url": "http://richardhendricks.example.com",
+		"summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinal!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
+		"location": {
+			"address": "2712 Broadway St",
+			"postalCode": "CA 94115",
+			"city": "San Francisco",
+			"countryCode": "US",
+			"region": "California"
+		},
+		"profiles": [
+			{
+				"network": "Twitter",
+				"username": "neutralthoughts",
+				"url": "https://www.twitter.com"
+			},
+			{
+				"network": "SoundCloud",
+				"username": "dandymusicnl",
+				"url": "https://soundcloud.example.com/dandymusicnl"
+			}
+		]
+	},
+	"work": [
+		{
+			"name": "Pied Piper",
+			"location": "Palo Alto, CA",
+			"description": "Awesome compression company",
+			"position": "CEO/President",
+			"url": "http://piedpiper.example.com",
+			"startDate": "2013-12-01",
+			"endDate": "2014-12-01",
+			"summary": "Pied Piper is a multi-platform technology based on a proprietary universal compression algorithm that has consistently fielded high Weisman Scores™ that are not merely competitive, but approach the theoretical limit of lossless compression.",
+			"highlights": [
+				"Build an algorithm for artist to detect if their music was violating copy right infringement laws",
+				"Successfully won Techcrunch Disrupt",
+				"Optimized an algorithm that holds the current world record for Weisman Scores"
+			]
+		}
+	],
+	"volunteer": [
+		{
+			"organization": "CoderDojo",
+			"position": "Teacher",
+			"url": "http://coderdojo.example.com/",
+			"startDate": "2012-01-01",
+			"endDate": "2013-01-01",
+			"summary": "Global movement of free coding clubs for young people.",
+			"highlights": [
+				"Awarded 'Teacher of the Month'"
+			]
+		}
+	],
+	"education": [
+		{
+			"institution": "University of Oklahoma",
+			"url": "https://www.ou.edu/",
+			"area": "Information Technology",
+			"studyType": "Bachelor",
+			"startDate": "2011-06-01",
+			"endDate": "2014-01-01",
+			"score": "4.0",
+			"courses": [
+				"DB1101 - Basic SQL",
+				"CS2011 - Java Introduction"
+			]
+		}
+	],
+	"awards": [
+		{
+			"title": "Digital Compression Pioneer Award",
+			"date": "2014-11-01",
+			"awarder": "Techcrunch",
+			"summary": "There is no spoon."
+		}
+	],
+	"publications": [
+		{
+			"name": "Video compression for 3d media",
+			"publisher": "Hooli",
+			"releaseDate": "2014-10-01",
+			"url": "http://en.wikipedia.org/wiki/Silicon_Valley_(TV_series)",
+			"summary": "Innovative middle-out compression algorithm that changes the way we store data."
+		}
+	],
+	"skills": [
+		{
+			"name": "Web Development",
+			"level": "Master",
+			"keywords": [
+				"HTML",
+				"CSS",
+				"Javascript"
+			]
+		},
+		{
+			"name": "Compression",
+			"level": "Master",
+			"keywords": [
+				"Mpeg",
+				"MP4",
+				"GIF"
+			]
+		}
+	],
+	"languages": [
+		{
+			"language": "English",
+			"fluency": "Native speaker"
+		}
+	],
+	"interests": [
+		{
+			"name": "Wildlife",
+			"keywords": [
+				"Ferrets",
+				"Unicorns"
+			]
+		}
+	],
+	"references": [
+		{
+			"name": "Erlich Bachman",
+			"reference": "It is my pleasure to recommend Richard, his performance working as a consultant for Main St. Company proved that he will be a valuable addition to any company."
+		}
+	],
+	"projects": [
+		{
+			"name": "Miss Direction",
+			"description": "A mapping engine that misguides you",
+			"highlights": [
+				"Won award at AIHacks 2016",
+				"Built by all women team of newbie programmers",
+				"Using modern technologies such as GoogleMaps, Chrome Extension and Javascript"
+			],
+			"keywords": [
+				"GoogleMaps",
+				"Chrome Extension",
+				"Javascript"
+			],
+			"startDate": "2016-08-24",
+			"endDate": "2016-08-24",
+			"url": "http://missdirection.example.com",
+			"roles": [
+				"Team lead",
+				"Designer"
+			],
+			"entity": "Smoogle",
+			"type": "application"
+		}
+	],
+	"meta": {
+		"canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/sample.resume.json",
+		"version": "v1.0.0",
+		"lastModified": "2017-12-24T15:53:00"
+	}
 }

--- a/sample.resume.json
+++ b/sample.resume.json
@@ -1,12 +1,10 @@
 {
-	"$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
 	"basics": {
 		"name": "Richard Hendriks",
 		"label": "Programmer",
 		"image": "",
 		"email": "richard.hendriks@mail.com",
 		"phone": "(912) 555-4321",
-		"url": "http://richardhendricks.example.com",
 		"summary": "Richard hails from Tulsa. He has earned degrees from the University of Oklahoma and Stanford. (Go Sooners and Cardinal!) Before starting Pied Piper, he worked for Hooli as a part time software developer. While his work focuses on applied information theory, mostly optimizing lossless compression schema of both the length-limited and adaptive variants, his non-work interests range widely, everything from quantum computing to chaos theory. He could tell you about it, but THAT would NOT be a “length-limited” conversation!",
 		"location": {
 			"address": "2712 Broadway St",
@@ -15,22 +13,20 @@
 			"countryCode": "US",
 			"region": "California"
 		},
-		"profiles": [
+		"links": [
 			{
-				"network": "Twitter",
-				"username": "neutralthoughts",
-				"url": "https://www.twitter.com"
+				"url": "https://www.twitter.com/neutralthoughts",
+				"label": "@neutralthoughts"
 			},
 			{
-				"network": "SoundCloud",
-				"username": "dandymusicnl",
-				"url": "https://soundcloud.example.com/dandymusicnl"
+				"url": "https://soundcloud.example.com/dandymusicnl",
+				"label": "@dandymusicnl"
 			}
 		]
 	},
 	"work": [
 		{
-			"name": "Pied Piper",
+			"employer": "Pied Piper",
 			"location": "Palo Alto, CA",
 			"description": "Awesome compression company",
 			"position": "CEO/President",
@@ -63,10 +59,16 @@
 			"institution": "University of Oklahoma",
 			"url": "https://www.ou.edu/",
 			"area": "Information Technology",
-			"studyType": "Bachelor",
 			"startDate": "2011-06-01",
 			"endDate": "2014-01-01",
-			"score": "4.0",
+			"programs": [
+				{
+					"type": "Degree",
+					"designation": "Bachelor of Science/B.S.",
+					"name": "Information Technology",
+					"gpa": "4.0"
+				}
+			],
 			"courses": [
 				"DB1101 - Basic SQL",
 				"CS2011 - Java Introduction"
@@ -93,7 +95,7 @@
 	"skills": [
 		{
 			"name": "Web Development",
-			"level": "Master",
+			"level": "Advanced",
 			"keywords": [
 				"HTML",
 				"CSS",
@@ -102,7 +104,7 @@
 		},
 		{
 			"name": "Compression",
-			"level": "Master",
+			"level": "Intermediate",
 			"keywords": [
 				"Mpeg",
 				"MP4",
@@ -113,7 +115,7 @@
 	"languages": [
 		{
 			"language": "English",
-			"fluency": "Native speaker"
+			"fluency": "Native"
 		}
 	],
 	"interests": [
@@ -158,7 +160,7 @@
 	],
 	"meta": {
 		"canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/sample.resume.json",
-		"version": "v1.0.0",
-		"lastModified": "2017-12-24T15:53:00"
+		"version": "1.0.0",
+		"lastModified": "2026-02-27T00:00:00.000Z"
 	}
 }

--- a/schema.json
+++ b/schema.json
@@ -25,16 +25,16 @@
 				},
 				"email": {
 					"type": "string",
-					"description": "The subject's email address, e.g. thomas@gmail.com",
+					"description": "The subject's email address, e.g. 'thomas@gmail.com'.",
 					"format": "email"
 				},
 				"phone": {
 					"type": "string",
-					"description": "The contact phone number of the subject.Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923."
+					"description": "The contact phone number of the subject. Phone numbers are stored as strings so use any format preferred, e.g.'712-117-2923'."
 				},
 				"summary": {
 					"type": "string",
-					"description": "Write a short 2-3 sentence biography about yourself."
+					"description": "A short 2-3 sentence biography about the subject."
 				},
 				"location": {
 					"description": "Where the subject is from. Can be a general region or their exact home address.",
@@ -69,45 +69,51 @@
 				"type": "object",
 				"additionalProperties": false,
 				"properties": {
-					"name": {
+					"employer": {
 						"type": "string",
-						"description": "e.g. Facebook"
+						"description": "The name of the company, e.g. 'Facebook'."
 					},
 					"location": {
 						"type": "string",
-						"description": "e.g. Menlo Park, CA"
+						"description": "The location the job is/was, e.g. 'Menlo Park, CA'. If the job is/was remote, specify 'Remote'."
 					},
 					"description": {
 						"type": "string",
-						"description": "e.g. Social Media Company"
+						"description": "A short, 1 sentence maximum description of the company, e.g. 'Social Media Company'."
 					},
 					"position": {
 						"type": "string",
-						"description": "e.g. Software Engineer"
+						"description": "The title of the role, e.g. 'Software Engineer'."
 					},
 					"url": {
 						"type": "string",
-						"description": "e.g. http://facebook.example.com",
+						"description": "The relevant URL of the company's homepage, e.g. 'http://facebook.example.com'.",
 						"format": "uri"
 					},
 					"startDate": {
+						"description": "The date on which this position was started.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
+						"description": "The date on which this position was stopped. If this job is ongoing, specify 'Present' as the value for this key.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"summary": {
 						"type": "string",
-						"description": "Give an overview of your responsibilities at the company"
+						"description": "An overview of the responsibilities at the company. No more than 3-5 sentences."
 					},
 					"highlights": {
 						"type": "array",
-						"description": "Specify multiple accomplishments",
+						"description": "A list of the key highlights of the volunteer role. For best results, use the XYZ formula with quantifiable attributes.",
 						"additionalItems": false,
 						"items": {
 							"type": "string",
-							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising."
 						}
+					},
+					"keywords": {
+						"description": "A list of keywords pertaining to this job position.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}
@@ -121,35 +127,41 @@
 				"properties": {
 					"organization": {
 						"type": "string",
-						"description": "e.g. Facebook"
+						"description": "The name of the volunteer organization, e.g. 'American Red Cross'."
 					},
 					"position": {
 						"type": "string",
-						"description": "e.g. Software Engineer"
+						"description": "The title of the volunteer role, e.g. 'Customer Service Representative'."
 					},
 					"url": {
 						"type": "string",
-						"description": "e.g. http://facebook.example.com",
+						"description": "The relevant URL of the volunteer organization's homepage, e.g. 'http://redcross.example.com'.",
 						"format": "uri"
 					},
 					"startDate": {
+						"description": "The date on which this volunteer position was started.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
+						"description": "The date on which this volunteer position was stopped. If this job is ongoing, specify 'Present' as the value for this key.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"summary": {
 						"type": "string",
-						"description": "Give an overview of your responsibilities at the company"
+						"description": "An overview of the responsibilities at the volunteer organization. No more than 3-5 sentences."
 					},
 					"highlights": {
 						"type": "array",
-						"description": "Specify accomplishments and achievements",
+						"description": "A list of the key highlights of the volunteer role. For best results, use the XYZ formula with quantifiable attributes.",
 						"additionalItems": false,
 						"items": {
 							"type": "string",
-							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising."
 						}
+					},
+					"keywords": {
+						"description": "A list of keywords pertaining to this volunteer position.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}

--- a/schema.json
+++ b/schema.json
@@ -525,6 +525,10 @@
 				"type": "object",
 				"additionalProperties": false,
 				"properties": {
+					"id": {
+						"type": "string",
+						"description": "The ID number of the project for cross-referencing purposes."
+					},
 					"name": {
 						"type": "string",
 						"description": "The name of the project, e.g. 'The World Wide Web'."

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "http://example.com/example.json",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/schema.json",
+	"title": "Resume Schema",
+	"version": "2.0.0",
+	"type": "object",
 	"additionalProperties": true,
 	"definitions": {
 		"iso8601": {
@@ -493,7 +496,5 @@
 				}
 			}
 		}
-	},
-	"title": "Resume Schema",
-	"type": "object"
+	}
 }

--- a/schema.json
+++ b/schema.json
@@ -112,6 +112,15 @@
 							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising."
 						}
 					},
+					"crossReferencedProjects": {
+						"type": "array",
+						"description": "A list of the IDs of the projects that are cross-referenced with this job. Particularly useful for consulting roles.",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "The ID number of the project for cross-referencing purposes."
+						}
+					},
 					"keywords": {
 						"description": "A list of keywords pertaining to this job position.",
 						"$ref": "types.json#/definitions/keywords"

--- a/schema.json
+++ b/schema.json
@@ -276,14 +276,43 @@
 					},
 					"awards": {
 						"type": "array",
+						"additionalItems": false,
 						"description": "Awards or honors earned for this program, e.g. 'Dean's List', 'Graduated with Honors'.",
 						"items": {
 							"type": "string"
 						}
 					},
+					"honorSocieties": {
+						"type": "array",
+						"description": "A list of honor societies inducted into during the completion of education at this institution.",
+						"additionalItems": false,
+						"items": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "The name of the honor society, e.g. 'Phi Beta Kappa'."
+								},
+								"chapter": {
+									"type": "string",
+									"description": "The specific chapter of the honor society, if applicable, e.g. 'Omega'."
+								},
+								"memberId": {
+									"type": "string",
+									"description": "The relevant membership ID, if applicable."
+								},
+								"inductionDate": {
+									"description": "The date of induction into the honor society.",
+									"$ref": "types.json#/definitions/iso8601"
+								}
+							}
+						}
+					},
 					"extracurriculars": {
 						"type": "array",
 						"description": "A list of relevant extracurricular activities participated in while a student at the institution, e.g. 'Bird Watching Club', 'Association of Computing Machinery'.",
+						"additionalItems": false,
 						"items": {
 							"type": "string"
 						}

--- a/schema.json
+++ b/schema.json
@@ -443,8 +443,8 @@
 						"description": "The name of the skill, e.g. 'Web Development'."
 					},
 					"level": {
-						"description": "The experience level of the skill, e.g. 'Senior', 'Junior', 'Mid-level'.",
-						"$ref": "types.json#/definitions/experienceLevel"
+						"description": "The experience level of the skill, e.g. 'Novice', 'Intermediate', 'Advanced', etc.",
+						"$ref": "types.json#/definitions/masteryLevel"
 					},
 					"keywords": {
 						"description": "A list of keywords pertaining to this skill.",

--- a/schema.json
+++ b/schema.json
@@ -1,17 +1,10 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/schema.json",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/schema.json#",
 	"title": "Resume Schema",
 	"version": "2.0.0",
 	"type": "object",
 	"additionalProperties": true,
-	"definitions": {
-		"iso8601": {
-			"type": "string",
-			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
-			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
-		}
-	},
 	"properties": {
 		"$schema": {
 			"type": "string",
@@ -130,10 +123,10 @@
 						"format": "uri"
 					},
 					"startDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"summary": {
 						"type": "string",
@@ -172,10 +165,10 @@
 						"format": "uri"
 					},
 					"startDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"summary": {
 						"type": "string",
@@ -218,10 +211,10 @@
 						"description": "e.g. Bachelor"
 					},
 					"startDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"score": {
 						"type": "string",
@@ -252,7 +245,7 @@
 						"description": "e.g. One of the 100 greatest minds of the century"
 					},
 					"date": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"awarder": {
 						"type": "string",
@@ -278,7 +271,7 @@
 						"description": "e.g. Certified Kubernetes Administrator"
 					},
 					"date": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"url": {
 						"type": "string",
@@ -309,7 +302,7 @@
 						"description": "e.g. IEEE, Computer Magazine"
 					},
 					"releaseDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"url": {
 						"type": "string",
@@ -446,10 +439,10 @@
 						}
 					},
 					"startDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
-						"$ref": "#/definitions/iso8601"
+						"$ref": "types.json#/definitions/iso8601"
 					},
 					"url": {
 						"type": "string",

--- a/schema.json
+++ b/schema.json
@@ -1,93 +1,61 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/schema.json#",
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/schema.json",
 	"title": "Resume Schema",
 	"version": "2.0.0",
 	"type": "object",
-	"additionalProperties": true,
+	"additionalProperties": false,
 	"properties": {
-		"$schema": {
-			"type": "string",
-			"description": "link to the version of the schema that can validate the resume",
-			"format": "uri"
-		},
 		"basics": {
 			"type": "object",
-			"additionalProperties": true,
+			"additionalProperties": false,
 			"properties": {
 				"name": {
-					"type": "string"
+					"type": "string",
+					"description": "The name of the resume's subject."
 				},
 				"label": {
 					"type": "string",
-					"description": "e.g. Web Developer"
+					"description": "The subject's professional title, e.g. Web Developer."
 				},
 				"image": {
 					"type": "string",
-					"description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
+					"description": "URL (as per RFC 3986) to a image in JPEG or PNG format.",
+					"format": "uri"
 				},
 				"email": {
 					"type": "string",
-					"description": "e.g. thomas@gmail.com",
+					"description": "The subject's email address, e.g. thomas@gmail.com",
 					"format": "email"
 				},
 				"phone": {
 					"type": "string",
-					"description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
-				},
-				"url": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
-					"format": "uri"
+					"description": "The contact phone number of the subject.Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923."
 				},
 				"summary": {
 					"type": "string",
-					"description": "Write a short 2-3 sentence biography about yourself"
+					"description": "Write a short 2-3 sentence biography about yourself."
 				},
 				"location": {
-					"type": "object",
-					"additionalProperties": true,
-					"properties": {
-						"address": {
-							"type": "string",
-							"description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
-						},
-						"postalCode": {
-							"type": "string"
-						},
-						"city": {
-							"type": "string"
-						},
-						"countryCode": {
-							"type": "string",
-							"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
-						},
-						"region": {
-							"type": "string",
-							"description": "The general region where you live. Can be a US state, or a province, for instance."
-						}
-					}
+					"description": "Where the subject is from. Can be a general region or their exact home address.",
+					"$ref": "types.json#/definitions/location"
 				},
-				"profiles": {
+				"links": {
 					"type": "array",
-					"description": "Specify any number of social networks that you participate in",
+					"description": "A list of web links relevant to the subject, e.g. personal website, social media, portfolios, etc.",
 					"additionalItems": false,
 					"items": {
 						"type": "object",
-						"additionalProperties": true,
+						"additionalProperties": false,
 						"properties": {
-							"network": {
-								"type": "string",
-								"description": "e.g. Facebook or Twitter"
-							},
-							"username": {
-								"type": "string",
-								"description": "e.g. neutralthoughts"
-							},
 							"url": {
 								"type": "string",
-								"description": "e.g. http://twitter.example.com/neutralthoughts",
+								"description": "e.g. https://github.com/johndoe",
 								"format": "uri"
+							},
+							"label": {
+								"type": "string",
+								"description": "The label for the hyperlink, e.g. '@johndoe'."
 							}
 						}
 					}
@@ -99,7 +67,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
@@ -149,7 +117,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"organization": {
 						"type": "string",
@@ -191,7 +159,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"institution": {
 						"type": "string",
@@ -238,7 +206,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"title": {
 						"type": "string",
@@ -264,7 +232,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
@@ -291,7 +259,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
@@ -322,7 +290,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
@@ -333,13 +301,8 @@
 						"description": "e.g. Master"
 					},
 					"keywords": {
-						"type": "array",
-						"description": "List some keywords pertaining to this skill",
-						"additionalItems": false,
-						"items": {
-							"type": "string",
-							"description": "e.g. HTML"
-						}
+						"description": "A list of keywords pertaining to this skill.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}
@@ -350,7 +313,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"language": {
 						"type": "string",
@@ -368,19 +331,15 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
 						"description": "e.g. Philosophy"
 					},
 					"keywords": {
-						"type": "array",
-						"additionalItems": false,
-						"items": {
-							"type": "string",
-							"description": "e.g. Friedrich Nietzsche"
-						}
+						"description": "A list of keywords pertaining to this interest.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}
@@ -391,7 +350,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
@@ -410,7 +369,7 @@
 			"additionalItems": false,
 			"items": {
 				"type": "object",
-				"additionalProperties": true,
+				"additionalProperties": false,
 				"properties": {
 					"name": {
 						"type": "string",
@@ -430,13 +389,8 @@
 						}
 					},
 					"keywords": {
-						"type": "array",
-						"description": "Specify special elements involved",
-						"additionalItems": false,
-						"items": {
-							"type": "string",
-							"description": "e.g. AngularJS"
-						}
+						"description": "A list of keywords pertaining to this project.",
+						"$ref": "types.json#/definitions/keywords"
 					},
 					"startDate": {
 						"$ref": "types.json#/definitions/iso8601"
@@ -470,24 +424,10 @@
 			}
 		},
 		"meta": {
-			"type": "object",
-			"description": "The schema version and any other tooling configuration lives here",
-			"additionalProperties": true,
-			"properties": {
-				"canonical": {
-					"type": "string",
-					"description": "URL (as per RFC 3986) to latest version of this document",
-					"format": "uri"
-				},
-				"version": {
-					"type": "string",
-					"description": "A version field which follows semver - e.g. v1.0.0"
-				},
-				"lastModified": {
-					"type": "string",
-					"description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
-				}
-			}
+			"$ref": "types.json#/definitions/meta"
 		}
-	}
+	},
+	"required": [
+		"meta"
+	]
 }

--- a/schema.json
+++ b/schema.json
@@ -1,499 +1,499 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://example.com/example.json",
-  "additionalProperties": true,
-  "definitions": {
-    "iso8601": {
-      "type": "string",
-      "description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
-      "pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
-    }
-  },
-  "properties": {
-    "$schema": {
-      "type": "string",
-      "description": "link to the version of the schema that can validate the resume",
-      "format": "uri"
-    },
-    "basics": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "label": {
-          "type": "string",
-          "description": "e.g. Web Developer"
-        },
-        "image": {
-          "type": "string",
-          "description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
-        },
-        "email": {
-          "type": "string",
-          "description": "e.g. thomas@gmail.com",
-          "format": "email"
-        },
-        "phone": {
-          "type": "string",
-          "description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
-        },
-        "url": {
-          "type": "string",
-          "description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
-          "format": "uri"
-        },
-        "summary": {
-          "type": "string",
-          "description": "Write a short 2-3 sentence biography about yourself"
-        },
-        "location": {
-          "type": "object",
-          "additionalProperties": true,
-          "properties": {
-            "address": {
-              "type": "string",
-              "description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
-            },
-            "postalCode": {
-              "type": "string"
-            },
-            "city": {
-              "type": "string"
-            },
-            "countryCode": {
-              "type": "string",
-              "description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
-            },
-            "region": {
-              "type": "string",
-              "description": "The general region where you live. Can be a US state, or a province, for instance."
-            }
-          }
-        },
-        "profiles": {
-          "type": "array",
-          "description": "Specify any number of social networks that you participate in",
-          "additionalItems": false,
-          "items": {
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "network": {
-                "type": "string",
-                "description": "e.g. Facebook or Twitter"
-              },
-              "username": {
-                "type": "string",
-                "description": "e.g. neutralthoughts"
-              },
-              "url": {
-                "type": "string",
-                "description": "e.g. http://twitter.example.com/neutralthoughts",
-                "format": "uri"
-              }
-            }
-          }
-        }
-      }
-    },
-    "work": {
-      "type": "array",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "e.g. Facebook"
-          },
-          "location": {
-            "type": "string",
-            "description": "e.g. Menlo Park, CA"
-          },
-          "description": {
-            "type": "string",
-            "description": "e.g. Social Media Company"
-          },
-          "position": {
-            "type": "string",
-            "description": "e.g. Software Engineer"
-          },
-          "url": {
-            "type": "string",
-            "description": "e.g. http://facebook.example.com",
-            "format": "uri"
-          },
-          "startDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "endDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "summary": {
-            "type": "string",
-            "description": "Give an overview of your responsibilities at the company"
-          },
-          "highlights": {
-            "type": "array",
-            "description": "Specify multiple accomplishments",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-            }
-          }
-        }
-      }
-    },
-    "volunteer": {
-      "type": "array",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "organization": {
-            "type": "string",
-            "description": "e.g. Facebook"
-          },
-          "position": {
-            "type": "string",
-            "description": "e.g. Software Engineer"
-          },
-          "url": {
-            "type": "string",
-            "description": "e.g. http://facebook.example.com",
-            "format": "uri"
-          },
-          "startDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "endDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "summary": {
-            "type": "string",
-            "description": "Give an overview of your responsibilities at the company"
-          },
-          "highlights": {
-            "type": "array",
-            "description": "Specify accomplishments and achievements",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
-            }
-          }
-        }
-      }
-    },
-    "education": {
-      "type": "array",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "institution": {
-            "type": "string",
-            "description": "e.g. Massachusetts Institute of Technology"
-          },
-          "url": {
-            "type": "string",
-            "description": "e.g. http://facebook.example.com",
-            "format": "uri"
-          },
-          "area": {
-            "type": "string",
-            "description": "e.g. Arts"
-          },
-          "studyType": {
-            "type": "string",
-            "description": "e.g. Bachelor"
-          },
-          "startDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "endDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "score": {
-            "type": "string",
-            "description": "grade point average, e.g. 3.67/4.0"
-          },
-          "courses": {
-            "type": "array",
-            "description": "List notable courses/subjects",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. H1302 - Introduction to American history"
-            }
-          }
-        }
-      }
-    },
-    "awards": {
-      "type": "array",
-      "description": "Specify any awards you have received throughout your professional career",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "e.g. One of the 100 greatest minds of the century"
-          },
-          "date": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "awarder": {
-            "type": "string",
-            "description": "e.g. Time Magazine"
-          },
-          "summary": {
-            "type": "string",
-            "description": "e.g. Received for my work with Quantum Physics"
-          }
-        }
-      }
-    },
-    "certificates": {
-      "type": "array",
-      "description": "Specify any certificates you have received throughout your professional career",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "e.g. Certified Kubernetes Administrator"
-          },
-          "date": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "url": {
-            "type": "string",
-            "description": "e.g. http://example.com",
-            "format": "uri"
-          },
-          "issuer": {
-            "type": "string",
-            "description": "e.g. CNCF"
-          }
-        }
-      }
-    },
-    "publications": {
-      "type": "array",
-      "description": "Specify your publications through your career",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "e.g. The World Wide Web"
-          },
-          "publisher": {
-            "type": "string",
-            "description": "e.g. IEEE, Computer Magazine"
-          },
-          "releaseDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "url": {
-            "type": "string",
-            "description": "e.g. http://www.computer.org.example.com/csdl/mags/co/1996/10/rx069-abs.html",
-            "format": "uri"
-          },
-          "summary": {
-            "type": "string",
-            "description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
-          }
-        }
-      }
-    },
-    "skills": {
-      "type": "array",
-      "description": "List out your professional skill-set",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "e.g. Web Development"
-          },
-          "level": {
-            "type": "string",
-            "description": "e.g. Master"
-          },
-          "keywords": {
-            "type": "array",
-            "description": "List some keywords pertaining to this skill",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. HTML"
-            }
-          }
-        }
-      }
-    },
-    "languages": {
-      "type": "array",
-      "description": "List any other languages you speak",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "language": {
-            "type": "string",
-            "description": "e.g. English, Spanish"
-          },
-          "fluency": {
-            "type": "string",
-            "description": "e.g. Fluent, Beginner"
-          }
-        }
-      }
-    },
-    "interests": {
-      "type": "array",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "e.g. Philosophy"
-          },
-          "keywords": {
-            "type": "array",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. Friedrich Nietzsche"
-            }
-          }
-        }
-      }
-    },
-    "references": {
-      "type": "array",
-      "description": "List references you have received",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "e.g. Timothy Cook"
-          },
-          "reference": {
-            "type": "string",
-            "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
-          }
-        }
-      }
-    },
-    "projects": {
-      "type": "array",
-      "description": "Specify career projects",
-      "additionalItems": false,
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "e.g. The World Wide Web"
-          },
-          "description": {
-            "type": "string",
-            "description": "Short summary of project. e.g. Collated works of 2017."
-          },
-          "highlights": {
-            "type": "array",
-            "description": "Specify multiple features",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. Directs you close but not quite there"
-            }
-          },
-          "keywords": {
-            "type": "array",
-            "description": "Specify special elements involved",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. AngularJS"
-            }
-          },
-          "startDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "endDate": {
-            "$ref": "#/definitions/iso8601"
-          },
-          "url": {
-            "type": "string",
-            "format": "uri",
-            "description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
-          },
-          "roles": {
-            "type": "array",
-            "description": "Specify your role on this project or in company",
-            "additionalItems": false,
-            "items": {
-              "type": "string",
-              "description": "e.g. Team Lead, Speaker, Writer"
-            }
-          },
-          "entity": {
-            "type": "string",
-            "description": "Specify the relevant company/entity affiliations e.g. 'greenpeace', 'corporationXYZ'"
-          },
-          "type": {
-            "type": "string",
-            "description": " e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
-          }
-        }
-      }
-    },
-    "meta": {
-      "type": "object",
-      "description": "The schema version and any other tooling configuration lives here",
-      "additionalProperties": true,
-      "properties": {
-        "canonical": {
-          "type": "string",
-          "description": "URL (as per RFC 3986) to latest version of this document",
-          "format": "uri"
-        },
-        "version": {
-          "type": "string",
-          "description": "A version field which follows semver - e.g. v1.0.0"
-        },
-        "lastModified": {
-          "type": "string",
-          "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
-        }
-      }
-    }
-  },
-  "title": "Resume Schema",
-  "type": "object"
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "http://example.com/example.json",
+	"additionalProperties": true,
+	"definitions": {
+		"iso8601": {
+			"type": "string",
+			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04",
+			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+		}
+	},
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"description": "link to the version of the schema that can validate the resume",
+			"format": "uri"
+		},
+		"basics": {
+			"type": "object",
+			"additionalProperties": true,
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string",
+					"description": "e.g. Web Developer"
+				},
+				"image": {
+					"type": "string",
+					"description": "URL (as per RFC 3986) to a image in JPEG or PNG format"
+				},
+				"email": {
+					"type": "string",
+					"description": "e.g. thomas@gmail.com",
+					"format": "email"
+				},
+				"phone": {
+					"type": "string",
+					"description": "Phone numbers are stored as strings so use any format you like, e.g. 712-117-2923"
+				},
+				"url": {
+					"type": "string",
+					"description": "URL (as per RFC 3986) to your website, e.g. personal homepage",
+					"format": "uri"
+				},
+				"summary": {
+					"type": "string",
+					"description": "Write a short 2-3 sentence biography about yourself"
+				},
+				"location": {
+					"type": "object",
+					"additionalProperties": true,
+					"properties": {
+						"address": {
+							"type": "string",
+							"description": "To add multiple address lines, use \n. For example, 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li."
+						},
+						"postalCode": {
+							"type": "string"
+						},
+						"city": {
+							"type": "string"
+						},
+						"countryCode": {
+							"type": "string",
+							"description": "code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN"
+						},
+						"region": {
+							"type": "string",
+							"description": "The general region where you live. Can be a US state, or a province, for instance."
+						}
+					}
+				},
+				"profiles": {
+					"type": "array",
+					"description": "Specify any number of social networks that you participate in",
+					"additionalItems": false,
+					"items": {
+						"type": "object",
+						"additionalProperties": true,
+						"properties": {
+							"network": {
+								"type": "string",
+								"description": "e.g. Facebook or Twitter"
+							},
+							"username": {
+								"type": "string",
+								"description": "e.g. neutralthoughts"
+							},
+							"url": {
+								"type": "string",
+								"description": "e.g. http://twitter.example.com/neutralthoughts",
+								"format": "uri"
+							}
+						}
+					}
+				}
+			}
+		},
+		"work": {
+			"type": "array",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. Facebook"
+					},
+					"location": {
+						"type": "string",
+						"description": "e.g. Menlo Park, CA"
+					},
+					"description": {
+						"type": "string",
+						"description": "e.g. Social Media Company"
+					},
+					"position": {
+						"type": "string",
+						"description": "e.g. Software Engineer"
+					},
+					"url": {
+						"type": "string",
+						"description": "e.g. http://facebook.example.com",
+						"format": "uri"
+					},
+					"startDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"endDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"summary": {
+						"type": "string",
+						"description": "Give an overview of your responsibilities at the company"
+					},
+					"highlights": {
+						"type": "array",
+						"description": "Specify multiple accomplishments",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+						}
+					}
+				}
+			}
+		},
+		"volunteer": {
+			"type": "array",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"organization": {
+						"type": "string",
+						"description": "e.g. Facebook"
+					},
+					"position": {
+						"type": "string",
+						"description": "e.g. Software Engineer"
+					},
+					"url": {
+						"type": "string",
+						"description": "e.g. http://facebook.example.com",
+						"format": "uri"
+					},
+					"startDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"endDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"summary": {
+						"type": "string",
+						"description": "Give an overview of your responsibilities at the company"
+					},
+					"highlights": {
+						"type": "array",
+						"description": "Specify accomplishments and achievements",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising"
+						}
+					}
+				}
+			}
+		},
+		"education": {
+			"type": "array",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"institution": {
+						"type": "string",
+						"description": "e.g. Massachusetts Institute of Technology"
+					},
+					"url": {
+						"type": "string",
+						"description": "e.g. http://facebook.example.com",
+						"format": "uri"
+					},
+					"area": {
+						"type": "string",
+						"description": "e.g. Arts"
+					},
+					"studyType": {
+						"type": "string",
+						"description": "e.g. Bachelor"
+					},
+					"startDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"endDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"score": {
+						"type": "string",
+						"description": "grade point average, e.g. 3.67/4.0"
+					},
+					"courses": {
+						"type": "array",
+						"description": "List notable courses/subjects",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. H1302 - Introduction to American history"
+						}
+					}
+				}
+			}
+		},
+		"awards": {
+			"type": "array",
+			"description": "Specify any awards you have received throughout your professional career",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"title": {
+						"type": "string",
+						"description": "e.g. One of the 100 greatest minds of the century"
+					},
+					"date": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"awarder": {
+						"type": "string",
+						"description": "e.g. Time Magazine"
+					},
+					"summary": {
+						"type": "string",
+						"description": "e.g. Received for my work with Quantum Physics"
+					}
+				}
+			}
+		},
+		"certificates": {
+			"type": "array",
+			"description": "Specify any certificates you have received throughout your professional career",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. Certified Kubernetes Administrator"
+					},
+					"date": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"url": {
+						"type": "string",
+						"description": "e.g. http://example.com",
+						"format": "uri"
+					},
+					"issuer": {
+						"type": "string",
+						"description": "e.g. CNCF"
+					}
+				}
+			}
+		},
+		"publications": {
+			"type": "array",
+			"description": "Specify your publications through your career",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. The World Wide Web"
+					},
+					"publisher": {
+						"type": "string",
+						"description": "e.g. IEEE, Computer Magazine"
+					},
+					"releaseDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"url": {
+						"type": "string",
+						"description": "e.g. http://www.computer.org.example.com/csdl/mags/co/1996/10/rx069-abs.html",
+						"format": "uri"
+					},
+					"summary": {
+						"type": "string",
+						"description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+					}
+				}
+			}
+		},
+		"skills": {
+			"type": "array",
+			"description": "List out your professional skill-set",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. Web Development"
+					},
+					"level": {
+						"type": "string",
+						"description": "e.g. Master"
+					},
+					"keywords": {
+						"type": "array",
+						"description": "List some keywords pertaining to this skill",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. HTML"
+						}
+					}
+				}
+			}
+		},
+		"languages": {
+			"type": "array",
+			"description": "List any other languages you speak",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"language": {
+						"type": "string",
+						"description": "e.g. English, Spanish"
+					},
+					"fluency": {
+						"type": "string",
+						"description": "e.g. Fluent, Beginner"
+					}
+				}
+			}
+		},
+		"interests": {
+			"type": "array",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. Philosophy"
+					},
+					"keywords": {
+						"type": "array",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. Friedrich Nietzsche"
+						}
+					}
+				}
+			}
+		},
+		"references": {
+			"type": "array",
+			"description": "List references you have received",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. Timothy Cook"
+					},
+					"reference": {
+						"type": "string",
+						"description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+					}
+				}
+			}
+		},
+		"projects": {
+			"type": "array",
+			"description": "Specify career projects",
+			"additionalItems": false,
+			"items": {
+				"type": "object",
+				"additionalProperties": true,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "e.g. The World Wide Web"
+					},
+					"description": {
+						"type": "string",
+						"description": "Short summary of project. e.g. Collated works of 2017."
+					},
+					"highlights": {
+						"type": "array",
+						"description": "Specify multiple features",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. Directs you close but not quite there"
+						}
+					},
+					"keywords": {
+						"type": "array",
+						"description": "Specify special elements involved",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. AngularJS"
+						}
+					},
+					"startDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"endDate": {
+						"$ref": "#/definitions/iso8601"
+					},
+					"url": {
+						"type": "string",
+						"format": "uri",
+						"description": "e.g. http://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html"
+					},
+					"roles": {
+						"type": "array",
+						"description": "Specify your role on this project or in company",
+						"additionalItems": false,
+						"items": {
+							"type": "string",
+							"description": "e.g. Team Lead, Speaker, Writer"
+						}
+					},
+					"entity": {
+						"type": "string",
+						"description": "Specify the relevant company/entity affiliations e.g. 'greenpeace', 'corporationXYZ'"
+					},
+					"type": {
+						"type": "string",
+						"description": " e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
+					}
+				}
+			}
+		},
+		"meta": {
+			"type": "object",
+			"description": "The schema version and any other tooling configuration lives here",
+			"additionalProperties": true,
+			"properties": {
+				"canonical": {
+					"type": "string",
+					"description": "URL (as per RFC 3986) to latest version of this document",
+					"format": "uri"
+				},
+				"version": {
+					"type": "string",
+					"description": "A version field which follows semver - e.g. v1.0.0"
+				},
+				"lastModified": {
+					"type": "string",
+					"description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+				}
+			}
+		}
+	},
+	"title": "Resume Schema",
+	"type": "object"
 }

--- a/schema.json
+++ b/schema.json
@@ -20,7 +20,7 @@
 				},
 				"image": {
 					"type": "string",
-					"description": "URL (as per RFC 3986) to a image in JPEG or PNG format.",
+					"description": "URL (as per RFC 3986) to an image in JPEG or PNG format.",
 					"format": "uri"
 				},
 				"email": {
@@ -64,6 +64,7 @@
 		},
 		"work": {
 			"type": "array",
+			"description": "A list of past and present professional work done, sorted chronologically from latest to earliest.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -95,7 +96,7 @@
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
-						"description": "The date on which this position was stopped. If this job is ongoing, specify 'Present' as the value for this key.",
+						"description": "The date on which this position was stopped. If current and ongoing, specify a blank string as the value for this key.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"summary": {
@@ -120,6 +121,7 @@
 		},
 		"volunteer": {
 			"type": "array",
+			"description": "A list of past and present volunteer work done, sorted chronologically from latest to earliest.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -143,7 +145,7 @@
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
-						"description": "The date on which this volunteer position was stopped. If this job is ongoing, specify 'Present' as the value for this key.",
+						"description": "The date on which this volunteer position was stopped. If current and ongoing, specify a blank string as the value for this key.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"summary": {
@@ -168,6 +170,7 @@
 		},
 		"education": {
 			"type": "array",
+			"description": "A list of past and present institutions attended, sorted chronologically from latest to earliest.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -175,46 +178,130 @@
 				"properties": {
 					"institution": {
 						"type": "string",
-						"description": "e.g. Massachusetts Institute of Technology"
+						"description": "The name of the institution being attended, e.g. 'Massachusetts Institute of Technology'."
+					},
+					"subInstitution": {
+						"type": "string",
+						"description": "A specific college/school/department within the institution, e.g. 'College of Arts and Humanities'."
 					},
 					"url": {
 						"type": "string",
-						"description": "e.g. http://facebook.example.com",
+						"description": "The relevant URL of the institution's homepage, e.g. 'http://example.com.edu'.",
 						"format": "uri"
+					},
+					"subInstitutionUrl": {
+						"type": "string",
+						"description": "The relevant URL of the sub-institution's homepage, if different, e.g. 'https://example.com.edu/arts-humanities'.",
+						"format": "uri"
+					},
+					"location": {
+						"type": "string",
+						"description": "The location of the institution, e.g. 'Boston, MA'."
 					},
 					"area": {
 						"type": "string",
-						"description": "e.g. Arts"
+						"description": "The broad area of study, e.g. 'Engineering', 'Humanities'."
 					},
-					"studyType": {
-						"type": "string",
-						"description": "e.g. Bachelor"
+					"programs": {
+						"type": "array",
+						"description": "One or more programs/majors pursued at this institution. Each item includes a degree designation and a name.",
+						"minItems": 1,
+						"items": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"type": {
+									"type": "string",
+									"description": "The broad education type for this program.",
+									"enum": [
+										"Degree",
+										"Certificate",
+										"Diploma",
+										"Non-Degree",
+										"Professional",
+										"Other"
+									]
+								},
+								"designation": {
+									"type": "string",
+									"description": "The degree designation or abbreviation of it, e.g. 'Bachelor of Science/B.S.', 'Master of Arts/M.A.', 'Associate of Applied Science/A.A.S'."
+								},
+								"name": {
+									"type": "string",
+									"description": "Specific major/minor name, e.g. 'Computer Science', 'Economics'."
+								},
+								"concentration": {
+									"type": "string",
+									"description": "Concentration or track within the major/minor, if applicable, e.g., 'Artificial Intelligence'."
+								},
+								"minor": {
+									"type": "boolean",
+									"description": "Indicates if this program is a minor rather than a major."
+								},
+								"gpa": {
+									"type": "string",
+									"description": "The cumulative grade point average (GPA) for this program, e.g. '3.67/4.0'."
+								},
+								"honors": {
+									"type": "string",
+									"description": "Honors or distinctions associated with this program, e.g., 'Summa Cum Laude'."
+								}
+							},
+							"required": [
+								"name",
+								"type"
+							]
+						}
 					},
 					"startDate": {
+						"description": "The date on which the education at this institution was started.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
+						"description": "The date on which the education at this institution was stopped. If current and ongoing, specify a blank string as the value for this key.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
-					"score": {
+					"gpa": {
 						"type": "string",
-						"description": "grade point average, e.g. 3.67/4.0"
+						"description": "The cumulative grade point average (GPA), e.g. '3.67/4.0'."
 					},
 					"courses": {
 						"type": "array",
-						"description": "List notable courses/subjects",
+						"description": "A list of relevant courses/subjects.",
 						"additionalItems": false,
 						"items": {
 							"type": "string",
-							"description": "e.g. H1302 - Introduction to American history"
+							"description": "The course id/code and name, e.g. 'H1302 - Introduction to American History'."
 						}
+					},
+					"awards": {
+						"type": "array",
+						"description": "Awards or honors earned for this program, e.g. 'Dean's List', 'Graduated with Honors'.",
+						"items": {
+							"type": "string"
+						}
+					},
+					"extracurriculars": {
+						"type": "array",
+						"description": "A list of relevant extracurricular activities participated in while a student at the institution, e.g. 'Bird Watching Club', 'Association of Computing Machinery'.",
+						"items": {
+							"type": "string"
+						}
+					},
+					"keywords": {
+						"description": "A list of keywords pertaining to this education.",
+						"$ref": "types.json#/definitions/keywords"
+					},
+					"notes": {
+						"type": "string",
+						"description": "Optional free-text notes, e.g. 'part-time study', 'transfer credits'."
 					}
 				}
 			}
 		},
 		"awards": {
 			"type": "array",
-			"description": "Specify any awards you have received throughout your professional career",
+			"description": "A list of awards and distinctions received, sorted chronologically from latest to earliest.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -222,25 +309,29 @@
 				"properties": {
 					"title": {
 						"type": "string",
-						"description": "e.g. One of the 100 greatest minds of the century"
+						"description": "The title of the award, e.g. 'Nobel Peace Prize'."
 					},
 					"date": {
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"awarder": {
 						"type": "string",
-						"description": "e.g. Time Magazine"
+						"description": "The organization or entity that conferred the award, e.g. 'Time Magazine'."
 					},
 					"summary": {
 						"type": "string",
-						"description": "e.g. Received for my work with Quantum Physics"
+						"description": "A short 1-2 sentence description of the award, e.g. 'Received for my work with Quantum Physics'."
+					},
+					"keywords": {
+						"description": "A list of keywords pertaining to this award.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}
 		},
 		"certificates": {
 			"type": "array",
-			"description": "Specify any certificates you have received throughout your professional career",
+			"description": "A list of certificates awarded, sorted chronologically from latest to earliest.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -248,26 +339,35 @@
 				"properties": {
 					"name": {
 						"type": "string",
-						"description": "e.g. Certified Kubernetes Administrator"
+						"description": "The title of the certificate, e.g. 'Certified Kubernetes Administrator'."
 					},
 					"date": {
+						"description": "The date the certificate was issued.",
 						"$ref": "types.json#/definitions/iso8601"
-					},
-					"url": {
-						"type": "string",
-						"description": "e.g. http://example.com",
-						"format": "uri"
 					},
 					"issuer": {
 						"type": "string",
-						"description": "e.g. CNCF"
+						"description": "The organization or entity that awarded the certificate, e.g. 'CNCF'."
+					},
+					"url": {
+						"type": "string",
+						"description": "The relevant URL of the awarding organization's homepage, e.g. 'http://example.com'.",
+						"format": "uri"
+					},
+					"id": {
+						"type": "string",
+						"description": "The ID number of the certificate for verification purposes, if applicable."
+					},
+					"keywords": {
+						"description": "A list of keywords pertaining to this certificate.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}
 		},
 		"publications": {
 			"type": "array",
-			"description": "Specify your publications through your career",
+			"description": "A list of past and present publications made, sorted chronologically from latest to earliest.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -275,13 +375,14 @@
 				"properties": {
 					"name": {
 						"type": "string",
-						"description": "e.g. The World Wide Web"
+						"description": "The name of the publication, e.g. 'The World Wide Web'."
 					},
 					"publisher": {
 						"type": "string",
-						"description": "e.g. IEEE, Computer Magazine"
+						"description": "The name of the organization or entity that published the publication, e.g. 'IEEE, Computer Magazine'."
 					},
 					"releaseDate": {
+						"description": "The date of the publication.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"url": {
@@ -291,14 +392,18 @@
 					},
 					"summary": {
 						"type": "string",
-						"description": "Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML."
+						"description": "A short summary of publication, e.g. 'Discussion of the World Wide Web, HTTP, HTML'."
+					},
+					"keywords": {
+						"description": "A list of keywords pertaining to this publication.",
+						"$ref": "types.json#/definitions/keywords"
 					}
 				}
 			}
 		},
 		"skills": {
 			"type": "array",
-			"description": "List out your professional skill-set",
+			"description": "A list of professional skills, including their mastery level.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -306,11 +411,11 @@
 				"properties": {
 					"name": {
 						"type": "string",
-						"description": "e.g. Web Development"
+						"description": "The name of the skill, e.g. 'Web Development'."
 					},
 					"level": {
-						"type": "string",
-						"description": "e.g. Master"
+						"description": "The experience level of the skill, e.g. 'Senior', 'Junior', 'Mid-level'.",
+						"$ref": "types.json#/definitions/experienceLevel"
 					},
 					"keywords": {
 						"description": "A list of keywords pertaining to this skill.",
@@ -321,7 +426,7 @@
 		},
 		"languages": {
 			"type": "array",
-			"description": "List any other languages you speak",
+			"description": "A list of languages spoken and/or written.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -333,13 +438,21 @@
 					},
 					"fluency": {
 						"type": "string",
-						"description": "e.g. Fluent, Beginner"
+						"description": "The proficiency in utilizing this language according to the CEFR.",
+						"enum": [
+							"Beginner",
+							"Intermediate",
+							"Advanced",
+							"Proficient",
+							"Native"
+						]
 					}
 				}
 			}
 		},
 		"interests": {
 			"type": "array",
+			"description": "A list of personal interests that lie outside one's professional work (i.e. hobbies).",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -347,7 +460,7 @@
 				"properties": {
 					"name": {
 						"type": "string",
-						"description": "e.g. Philosophy"
+						"description": "The name of the interest, e.g. 'Philosophy'."
 					},
 					"keywords": {
 						"description": "A list of keywords pertaining to this interest.",
@@ -358,7 +471,7 @@
 		},
 		"references": {
 			"type": "array",
-			"description": "List references you have received",
+			"description": "A list of references/letters of recommendation received.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -366,7 +479,7 @@
 				"properties": {
 					"name": {
 						"type": "string",
-						"description": "e.g. Timothy Cook"
+						"description": "The person who wrote the reference, e.g. 'Timothy Cook'."
 					},
 					"reference": {
 						"type": "string",
@@ -377,7 +490,7 @@
 		},
 		"projects": {
 			"type": "array",
-			"description": "Specify career projects",
+			"description": "A list of past and present professional or personal projects done, sorted chronologically from latest to earliest.",
 			"additionalItems": false,
 			"items": {
 				"type": "object",
@@ -385,19 +498,19 @@
 				"properties": {
 					"name": {
 						"type": "string",
-						"description": "e.g. The World Wide Web"
+						"description": "The name of the project, e.g. 'The World Wide Web'."
 					},
 					"description": {
 						"type": "string",
-						"description": "Short summary of project. e.g. Collated works of 2017."
+						"description": "A short summary of project in 1-3 sentences. e.g. 'Collated works of 2017'."
 					},
 					"highlights": {
 						"type": "array",
-						"description": "Specify multiple features",
+						"description": "A list of the key highlights of the project. For best results, use the XYZ formula with quantifiable attributes.",
 						"additionalItems": false,
 						"items": {
 							"type": "string",
-							"description": "e.g. Directs you close but not quite there"
+							"description": "e.g. Increased profits by 20% from 2011-2012 through viral advertising."
 						}
 					},
 					"keywords": {
@@ -405,9 +518,11 @@
 						"$ref": "types.json#/definitions/keywords"
 					},
 					"startDate": {
+						"description": "The date on which work on this project was started.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"endDate": {
+						"description": "The date on which work on this project was stopped. If current and ongoing, specify a blank string as the value for this key.",
 						"$ref": "types.json#/definitions/iso8601"
 					},
 					"url": {
@@ -417,7 +532,7 @@
 					},
 					"roles": {
 						"type": "array",
-						"description": "Specify your role on this project or in company",
+						"description": "A list of the roles taken on during the development of the project.",
 						"additionalItems": false,
 						"items": {
 							"type": "string",
@@ -426,7 +541,7 @@
 					},
 					"entity": {
 						"type": "string",
-						"description": "Specify the relevant company/entity affiliations e.g. 'greenpeace', 'corporationXYZ'"
+						"description": "The relevant company/entity affiliations, if any, e.g. 'greenpeace', 'corporationXYZ'."
 					},
 					"type": {
 						"type": "string",

--- a/types.json
+++ b/types.json
@@ -37,6 +37,15 @@
 				"Unspecified"
 			]
 		},
+		"keywords": {
+			"type": "array",
+			"description": "A list of keywords that are related to the parent object. Due to the nature of being keywords, the items within may have aliases attached. However, each item should appear ONCE and matched on using a separate dictionary to keep this array as slim as possible.",
+			"additionalItems": false,
+			"items": {
+				"type": "string",
+				"description": "e.g. HTML"
+			}
+		},
 		"location": {
 			"type": "object",
 			"description": "A location in the world. Can be a full address, a partial address, or simply a listing of the country and region.",
@@ -82,7 +91,7 @@
 			"properties": {
 				"canonical": {
 					"type": "string",
-					"description": "URL (as per RFC 3986) to latest version of this document",
+					"description": "URL (as per RFC 3986) to latest version of this document.",
 					"format": "uri"
 				},
 				"version": {
@@ -92,7 +101,7 @@
 				},
 				"lastModified": {
 					"type": "string",
-					"description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss",	
+					"description": "Using ISO 8601 with 'YYYY-MM-DDThh:mm:ss'.",
 					"format": "date-time"
 				}
 			}

--- a/types.json
+++ b/types.json
@@ -1,0 +1,48 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/types.json#",
+	"definitions": {
+		"experienceLevel": {
+			"type": "string",
+			"description": "The experience level of a position or candidate.",
+			"enum": [
+				"Internship",
+				"Entry-level",
+				"Junior",
+				"Mid-level",
+				"Senior",
+				"Lead",
+				"Director",
+				"Executive"
+			]
+		},
+		"iso8601": {
+			"type": "string",
+			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04.",
+			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+		},
+		"jobType": {
+			"type": "string",
+			"description": "The type of job this is, e.g. Full-time, part-time, contract, etc.",
+			"enum": [
+				"Part-Time",
+				"Full-Time",
+				"Seasonal",
+				"On-Demand",
+				"Contract",
+				"Unspecified"
+			]
+		},
+		"masteryLevel": {
+			"type": "string",
+			"description": "One of five mastery levels for a particular skill.",
+			"enum": [
+				"Novice",
+				"Intermediate",
+				"Advanced",
+				"Expert",
+				"Master"
+			]
+		}
+	}
+}

--- a/types.json
+++ b/types.json
@@ -1,6 +1,10 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/types.json#",
+	"title": "Job-Resume Typedefs Schema",
+	"version": "2.0.0",
+	"type": "object",
+	"additionalProperties": false,
 	"definitions": {
 		"experienceLevel": {
 			"type": "string",

--- a/types.json
+++ b/types.json
@@ -74,6 +74,27 @@
 				"Expert",
 				"Master"
 			]
+		},
+		"meta": {
+			"type": "object",
+			"description": "The schema version and any other tooling configuration lives here.",
+			"additionalProperties": false,
+			"properties": {
+				"canonical": {
+					"type": "string",
+					"description": "URL (as per RFC 3986) to latest version of this document",
+					"format": "uri"
+				},
+				"version": {
+					"type": "string",
+					"description": "A version field which follows semver - e.g. v1.0.0"
+				},
+				"lastModified": {
+					"type": "string",
+					"description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss",	
+					"format": "date-time"
+				}
+			}
 		}
 	}
 }

--- a/types.json
+++ b/types.json
@@ -1,6 +1,6 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/types.json#",
+	"$schema": "https://json-schema.org/draft-07/schema",
+	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/types.json",
 	"title": "Job-Resume Typedefs Schema",
 	"version": "v2.0.0",
 	"type": "object",

--- a/types.json
+++ b/types.json
@@ -87,7 +87,8 @@
 				},
 				"version": {
 					"type": "string",
-					"description": "A version field which follows semver - e.g. v1.0.0"
+					"description": "A version field which follows semver - e.g. `1.0.0`. Regexp is per the recommendation of semver.org",
+					"pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
 				},
 				"lastModified": {
 					"type": "string",

--- a/types.json
+++ b/types.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json-schema.org/draft-07/schema",
 	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/types.json",
 	"title": "Job-Resume Typedefs Schema",
-	"version": "v2.0.0",
+	"version": "2.0.0",
 	"type": "object",
 	"additionalProperties": false,
 	"definitions": {

--- a/types.json
+++ b/types.json
@@ -22,8 +22,8 @@
 		},
 		"iso8601": {
 			"type": "string",
-			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04.",
-			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$"
+			"description": "Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04. The value can also be an empty string for ongoing dates.",
+			"pattern": "^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3}|)$"
 		},
 		"jobType": {
 			"type": "string",

--- a/types.json
+++ b/types.json
@@ -104,7 +104,10 @@
 					"description": "Using ISO 8601 with 'YYYY-MM-DDThh:mm:ss'.",
 					"format": "date-time"
 				}
-			}
+			},
+			"required": [
+				"version"
+			]
 		}
 	}
 }

--- a/types.json
+++ b/types.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "https://raw.githubusercontent.com/jgilman1337/resume-schema/refs/heads/master/types.json#",
 	"title": "Job-Resume Typedefs Schema",
-	"version": "2.0.0",
+	"version": "v2.0.0",
 	"type": "object",
 	"additionalProperties": false,
 	"definitions": {
@@ -36,6 +36,33 @@
 				"Contract",
 				"Unspecified"
 			]
+		},
+		"location": {
+			"type": "object",
+			"description": "A location in the world. Can be a full address, a partial address, or simply a listing of the country and region.",
+			"additionalProperties": false,
+			"properties": {
+				"address": {
+					"type": "string",
+					"description": "The street name and number components of the location."
+				},
+				"postalCode": {
+					"type": "string",
+					"description": "Also known as a zip code for US addresses."
+				},
+				"city": {
+					"type": "string"
+				},
+				"countryCode": {
+					"type": "string",
+					"description": "Country code as per ISO-3166-1 ALPHA-2, e.g. US, AU, IN.",
+					"pattern": "[A-Z]{2}"
+				},
+				"region": {
+					"type": "string",
+					"description": "Can be a state, province, prefecture, oblast, etc."
+				}
+			}
 		},
 		"masteryLevel": {
 			"type": "string",


### PR DESCRIPTION
in consulting type rolers it is very useful to be able to list projects done. this adds a cross-ref from job schema to projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Stricter schema validation across jobs and resumes to prevent unknown fields and enforce required metadata
  * Centralized reusable types for dates, locations, levels, and meta information

* **New Features**
  * Added keywords support and an external keywords dictionary for consistent tagging
  * Added cross-referenced projects and optionalQualifications to job descriptions
  * Updated resume structure: links, employer field, programs, and tightened skills/language levels

* **Chores**
  * Sample data normalized and version/lastModified timestamps updated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->