### PR TITLE
feat(schema): add "basics.timeZone" string property

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -72,6 +72,10 @@
             }
           }
         },
+        "timeZone": {
+          "type": "string",
+          "description": "The time zone where you reside. Use IANA timezone codes, e.g. 'Africa/Johannesburg' or 'Etc/GMT+5' (note the inverted GMT sign)"
+        },
         "profiles": {
           "type": "array",
           "description": "Specify any number of social networks that you participate in",


### PR DESCRIPTION
nothing fancy
just a timezone identifier in the "basics" section

helps to calculate "the local time" for a person

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume profiles now include a time zone field using IANA time zone codes.
  * The time zone is displayed alongside existing location information in profile metadata, helping clarify timestamps and locale context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jsonresume/resume-schema/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->