### PR TITLE
chore: reconcile repo with published v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonresume/schema",
-  "version": "1.1.2",
+  "version": "1.2.1",
   "description": "JSON Resume Schema",
   "private": false,
   "main": "validator.js",


### PR DESCRIPTION
## Summary

Reconciles the repo's `package.json` version with the published npm artifact. The published `@jsonresume/schema` is at **v1.2.1** (published 2024-08-06) while `package.json` on `master` HEAD still read **1.1.2**. This PR bumps `package.json` `1.1.2` -> `1.2.1` so the source-of-truth version matches what is actually on npm.

Refs jsonresume/resume-schema#522, jsonresume/jsonresume.org#275.

## What was published vs. what's in the repo (evidence)

I downloaded `npm pack @jsonresume/schema@1.2.1` and compared every published file against repo HEAD (`50798e3`). SHA256 results:

| File | npm v1.2.1 vs repo HEAD |
| --- | --- |
| `schema.json` | identical |
| `job-schema.json` | identical |
| `sample.resume.json` | identical |
| `sample.job.json` | identical |
| `validator.js` | identical |
| `README.md` | identical |
| `LICENSE.md` | identical |
| `package.json` | **differs only in `version`** (`1.2.1` vs `1.1.2`) |

The published v1.2.1 contains **no schema changes** relative to repo HEAD. The entire delta is the one version string this PR updates. After this change the repo `package.json` is byte-identical to the published one.

## Root cause of the drift

`.github/workflows/main.yml` runs `cycjimmy/semantic-release-action` on push. semantic-release computes the next version from conventional commits, publishes to npm and creates a git tag, but with the default config it does **not** commit the bumped `package.json` back to the branch. So:

- The `v1.2.1` git tag exists and points at the same commit as HEAD (`50798e3`), yet `package.json` at that tag still reads `1.1.2`.
- There is no `v1.1.2` git tag at all, even though HEAD's `package.json` claims `1.1.2`.

In other words the in-repo `version` field has never tracked npm — it is bumped only in the publish pipeline, not in the tree. This PR fixes the current drift; a durable fix (have semantic-release's git plugin commit the bump back, or drop the in-repo version reliance) is a separate follow-up and is best decided by the maintainer.

## Verification

```
npm pack @jsonresume/schema@1.2.1        # fetch published artifact
# SHA256 of all 8 files compared: only package.json differs
diff npm/package/package.json repo/package.json   # => only "version" line
# after edit:
diff npm/package/package.json repo/package.json   # => identical, no output
```

No npm publish and no schema changes are performed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JSON Resume schema dependency to version 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->