### PR TITLE
ci: modernize deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -11,13 +11,13 @@ jobs:
         node: [18, 20]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
     name: Test on Node.js ${{ matrix.node }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -29,10 +29,10 @@ jobs:
     name: Release
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Setup
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
GitHub now auto-fails workflows using `actions/cache@v1` (and is deprecating `checkout@v1/v2`, `setup-node@v1`), which is why the **Verify** job has been red. Bumps all three to `@v4` (inputs unchanged) across latest.yml/main.yml/release.yml. Restores green CI on the schema repo. Part of jsonresume.org#275.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow automation by upgrading GitHub Actions across multiple pipelines. Checkout, Node.js setup, and dependency caching actions have been upgraded to their latest major versions, delivering improved platform compatibility, better performance, and alignment with current industry standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->